### PR TITLE
ENH: initial attempts at code summary layer, sphinx domain

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,7 @@
 *.py[co]
 *.sw[op]
+/old
+/build
+/dist
+*.egg-info
+.coverage

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -3,5 +3,5 @@ include requirements.txt
 include README.md
 include LICENSE
 include blark/_version.py
-include blark/iec.lark
-include blark/iec.grammar
+include blark/*.lark
+include blark/docs/*.css

--- a/blark/iec.lark
+++ b/blark/iec.lark
@@ -522,8 +522,9 @@ DOTTED_IDENTIFIER: IDENTIFIER ( "." IDENTIFIER )*
 
 ABSTRACT: "ABSTRACT"i
 extends: "EXTENDS"i DOTTED_IDENTIFIER
+implements: "IMPLEMENTS"i DOTTED_IDENTIFIER ("," DOTTED_IDENTIFIER)*
 
-function_block_type_declaration: FUNCTION_BLOCK [ ABSTRACT ] derived_function_block_name [ extends ] fb_var_declaration* [ function_block_body ] END_FUNCTION_BLOCK ";"*
+function_block_type_declaration: FUNCTION_BLOCK [ ABSTRACT ] derived_function_block_name [ extends ] [ implements ] fb_var_declaration* [ function_block_body ] END_FUNCTION_BLOCK ";"*
 
 FUNCTION_BLOCK: "FUNCTION_BLOCK"i
               | "FUNCTIONBLOCK"i
@@ -953,7 +954,3 @@ IL_OPERATOR_AND: "AND"i | "&"
 !?il_jump_operator: "JMP"i
                   | "JMPC"i
                   | "JMPCN"i
-
-// Missing:
-//   FB IMPLEMENTS (interface_list)
-//   INTERFACE

--- a/blark/iec.lark
+++ b/blark/iec.lark
@@ -413,6 +413,8 @@ structured_var_declaration: var1_list ":" structure_type_name
 
 var_declarations: "VAR"i [ var_declaration_config ] var_body "END_VAR"i ";"*
 
+static_var_declarations: "VAR_STAT"i var_body "END_VAR"i ";"*
+
 ?var_declaration_config: CONSTANT | PERSISTENT | RETAIN | NON_RETAIN
 
 located_var_declarations: "VAR"i [ located_var_config ] [ PERSISTENT ] located_var_decl* "END_VAR"i ";"*
@@ -491,13 +493,13 @@ string_type_specification: STRING [ STRING_SPEC_LENGTH ]
 // B.1.5.1
 ?derived_function_name: IDENTIFIER
 
-function_declaration: "FUNCTION"i derived_function_name [ ":" simple_specification ] ";"* [ function_var_blocks ] [ function_body ] "END_FUNCTION"i ";"*
+function_declaration: "FUNCTION"i derived_function_name [ ":" simple_specification ] ";"* [ function_var_block+ ] [ function_body ] "END_FUNCTION"i ";"*
 
-function_var_blocks: (_io_var_declarations | function_var_declarations)+
-
-_io_var_declarations: input_declarations
-                    | output_declarations
-                    | input_output_declarations
+?function_var_block: input_declarations
+                   | output_declarations
+                   | input_output_declarations
+                   | static_var_declarations
+                   | function_var_declarations
 
 function_var_declarations: "VAR"i [ CONSTANT ] var_body "END_VAR"i ";"*
 
@@ -532,13 +534,14 @@ FUNCTION_BLOCK: "FUNCTION_BLOCK"i
 END_FUNCTION_BLOCK: "END_FUNCTION_BLOCK"i
                   | "END_FUNCTIONBLOCK"i
 
-?fb_var_declaration: _io_var_declarations
-                   | _other_var_declarations
-
-_other_var_declarations: external_var_declarations
-                       | var_declarations
-                       | temp_var_decls
-                       | incomplete_located_var_declarations
+?fb_var_declaration: input_declarations
+                   | output_declarations
+                   | input_output_declarations
+                   | external_var_declarations
+                   | var_declarations
+                   | temp_var_decls
+                   | static_var_declarations
+                   | incomplete_located_var_declarations
 
 temp_var_decls: "VAR_TEMP"i var_body "END_VAR"i ";"*
 
@@ -560,6 +563,7 @@ var_inst_declaration: "VAR_INST"i var_body "END_VAR"i ";"*
 
 ?method_var_declaration: fb_var_declaration
                        | var_inst_declaration
+                       | static_var_declarations
 
 ?method_return_type: _located_var_spec_init
 
@@ -587,10 +591,16 @@ program_declaration: "PROGRAM"i program_type_name [ program_var_declarations ] [
 
 program_var_declarations: program_var_declaration+
 
-?program_var_declaration: _io_var_declarations
-                        | _other_var_declarations
+?program_var_declaration: input_declarations
+                        | output_declarations
+                        | input_output_declarations
+                        | external_var_declarations
+                        | incomplete_located_var_declarations
                         | located_var_declarations
                         | program_access_decls
+                        | static_var_declarations
+                        | temp_var_decls
+                        | var_declarations
 
 program_access_decls: "VAR_ACCESS"i (program_access_decl ";"+)+ "END_VAR"i ";"*
 

--- a/blark/iec.lark
+++ b/blark/iec.lark
@@ -238,16 +238,14 @@ REFERENCE_TO: /REFERENCE\s*TO/i
                          | subrange_type_name
                          | enumerated_type_name
 
-data_type_declaration: "TYPE"i _type_declaration* "END_TYPE"i ";"*
+data_type_declaration: "TYPE"i [ _type_declaration ] ";"* "END_TYPE"i ";"*
 
-_type_declaration: array_type_declaration ";"+
-                 | structure_type_declaration ";"*
-                 | string_type_declaration ";"+
-                 | _single_element_type_declaration ";"+
-
-_single_element_type_declaration: simple_type_declaration
-                                | subrange_type_declaration
-                                | enumerated_type_declaration
+_type_declaration: array_type_declaration
+                 | structure_type_declaration
+                 | string_type_declaration
+                 | simple_type_declaration
+                 | subrange_type_declaration
+                 | enumerated_type_declaration
 
 simple_type_declaration: simple_type_name [ extends ] ":" simple_spec_init
 

--- a/blark/iec.lark
+++ b/blark/iec.lark
@@ -161,7 +161,7 @@ _date_literal: year "-" month "-" day
 date_and_time: ( "DATE_AND_TIME"i | "DT"i ) "#" _date_literal "-" _daytime
 
 // B.1.3
-non_generic_type_name: [ pointer_type ] ( elementary_type_name | derived_type_name )
+non_generic_type_name: [ pointer_type ] ( elementary_type_name | derived_type_name | DOTTED_IDENTIFIER )
 
 // B.1.3.1
 TYPE_TOD: "TIME_OF_DAY"i
@@ -957,4 +957,3 @@ IL_OPERATOR_AND: "AND"i | "&"
 // Missing:
 //   FB IMPLEMENTS (interface_list)
 //   INTERFACE
-//   Merge back in instruction list grammar

--- a/blark/iec.lark
+++ b/blark/iec.lark
@@ -491,7 +491,7 @@ string_type_specification: STRING [ STRING_SPEC_LENGTH ]
 // B.1.5.1
 ?derived_function_name: IDENTIFIER
 
-function_declaration: "FUNCTION"i derived_function_name ":" ( elementary_type_name | derived_type_name ) ";"* [ function_var_blocks ] [ function_body ] "END_FUNCTION"i ";"*
+function_declaration: "FUNCTION"i derived_function_name [ ":" ( elementary_type_name | derived_type_name ) ] ";"* [ function_var_blocks ] [ function_body ] "END_FUNCTION"i ";"*
 
 function_var_blocks: (_io_var_declarations | function_var_declarations)+
 

--- a/blark/iec.lark
+++ b/blark/iec.lark
@@ -838,7 +838,7 @@ case_list: case_list_element ( "," case_list_element )*
                   | symbolic_variable
 
 // B.3.2.4
-?control_variable: IDENTIFIER
+?control_variable: symbolic_variable
 
 _iteration_statement: for_statement
                     | while_statement

--- a/blark/iec.lark
+++ b/blark/iec.lark
@@ -242,6 +242,7 @@ data_type_declaration: "TYPE"i [ _type_declaration ] ";"* "END_TYPE"i ";"*
 
 _type_declaration: array_type_declaration
                  | structure_type_declaration
+                 | union_type_declaration
                  | string_type_declaration
                  | simple_type_declaration
                  | subrange_type_declaration
@@ -305,15 +306,17 @@ _array_initial_element: constant
                       | structure_initialization
                       | enumerated_value
 
-structure_type_declaration: structure_type_name [ extends ] ":" [ indirection_type ] _structure_declaration
+structure_type_declaration: structure_type_name [ extends ] ":" [ indirection_type ] "STRUCT"i ( structure_element_declaration ";"+ )* "END_STRUCT"i
 
 initialized_structure_type_declaration: structure_type_name [ extends ] ":" initialized_structure
 
 initialized_structure: structure_type_name ":=" structure_initialization
 
-_structure_declaration: "STRUCT"i ( structure_element_declaration ";"+ )* "END_STRUCT"i ";"*
-
 structure_element_declaration: structure_element_name [ incomplete_location ] ":" ( initialized_structure | array_spec_init | simple_spec_init | subrange_spec_init | enumerated_spec_init )
+
+union_element_declaration: structure_element_name ":" ( array_specification | simple_specification | subrange_specification | enumerated_specification )
+
+union_type_declaration: structure_type_name ":" "UNION"i ( union_element_declaration ";"+ )* "END_UNION"i ";"*
 
 structure_initialization: "(" structure_element_initialization ( "," structure_element_initialization )* ")"
 

--- a/blark/iec.lark
+++ b/blark/iec.lark
@@ -523,13 +523,13 @@ DOTTED_IDENTIFIER: IDENTIFIER ( "." IDENTIFIER )*
 ABSTRACT: "ABSTRACT"i
 extends: "EXTENDS"i DOTTED_IDENTIFIER
 
-function_block_type_declaration: _FUNCTION_BLOCK [ ABSTRACT ] derived_function_block_name [ extends ] fb_var_declaration* [ function_block_body ] _END_FUNCTION_BLOCK ";"*
+function_block_type_declaration: FUNCTION_BLOCK [ ABSTRACT ] derived_function_block_name [ extends ] fb_var_declaration* [ function_block_body ] END_FUNCTION_BLOCK ";"*
 
-_FUNCTION_BLOCK: "FUNCTION_BLOCK"i
-               | "FUNCTIONBLOCK"i
+FUNCTION_BLOCK: "FUNCTION_BLOCK"i
+              | "FUNCTIONBLOCK"i
 
-_END_FUNCTION_BLOCK: "END_FUNCTION_BLOCK"i
-                   | "END_FUNCTIONBLOCK"i
+END_FUNCTION_BLOCK: "END_FUNCTION_BLOCK"i
+                  | "END_FUNCTIONBLOCK"i
 
 ?fb_var_declaration: _io_var_declarations
                    | _other_var_declarations

--- a/blark/iec.lark
+++ b/blark/iec.lark
@@ -491,7 +491,7 @@ string_type_specification: STRING [ STRING_SPEC_LENGTH ]
 // B.1.5.1
 ?derived_function_name: IDENTIFIER
 
-function_declaration: "FUNCTION"i derived_function_name [ ":" ( elementary_type_name | derived_type_name ) ] ";"* [ function_var_blocks ] [ function_body ] "END_FUNCTION"i ";"*
+function_declaration: "FUNCTION"i derived_function_name [ ":" simple_specification ] ";"* [ function_var_blocks ] [ function_body ] "END_FUNCTION"i ";"*
 
 function_var_blocks: (_io_var_declarations | function_var_declarations)+
 

--- a/blark/parse.py
+++ b/blark/parse.py
@@ -12,6 +12,7 @@ import pytmc
 
 import blark
 
+from . import summary
 from . import transform as tf
 from .transform import GrammarTransformer
 from .util import (find_and_clean_comments, get_source_code,
@@ -222,35 +223,8 @@ def build_arg_parser(argparser=None):
     return argparser
 
 
-def summarize(code):
-    if isinstance(code, tf.SourceCode):
-        for item in code.items:
-            summarize(item)
-    elif isinstance(code, tf.FunctionBlock):
-        try:
-            comments = code.meta.comments
-        except AttributeError:
-            comments = []
-        print("Function block", code.name, comments)
-        for decl in code.declarations:
-            print(type(decl).__name__, ":")
-            for item in decl.items:
-                try:
-                    comments = item.meta.comments
-                except AttributeError:
-                    comments = []
-
-                # OK, a bit lazy for now
-                try:
-                    spec = item.init.spec
-                except AttributeError:
-                    spec = "?"
-
-                print(
-                    "\t",
-                    " ".join(getattr(var, "name", var) for var in item.variables),
-                    f"({spec}) {comments}"
-                )
+def summarize(code: tf.SourceCode) -> summary.CodeSummary:
+    return summary.CodeSummary.from_source(code)
 
 
 def main(

--- a/blark/sphinxdomain.py
+++ b/blark/sphinxdomain.py
@@ -478,9 +478,9 @@ class ParameterNode(BlarkNode):
 class ElementWithDeclarations(BlarkNode):
     def get_render_context(self, translator: SphinxTranslator, format: str):
         decls = self["declarations"]
-        inputs = dict(decls.get("InputDeclarations", {}))
-        inputs.update(decls.get("InputOutputDeclarations", {}))
-        outputs = decls.get("OutputDeclarations", {})
+        inputs = dict(decls.get("VAR_INPUT", {}))
+        inputs.update(decls.get("VAR_IN_OUT", {}))
+        outputs = decls.get("VAR_OUTPUT", {})
         return dict(
             inputs=list(inputs.values()),
             outputs=list(outputs.values()),

--- a/blark/sphinxdomain.py
+++ b/blark/sphinxdomain.py
@@ -1,0 +1,575 @@
+from __future__ import annotations
+
+import dataclasses
+import functools
+import inspect
+import logging
+import textwrap
+from typing import ClassVar, Dict
+
+import jinja2
+import sphinx
+import sphinx.application
+from docutils import nodes
+from sphinx.directives import ObjectDescription
+from sphinx.domains import Domain, ObjType
+from sphinx.locale import _ as l_
+from sphinx.roles import XRefRole
+from sphinx.util.docfields import DocFieldTransformer, TypedField
+from sphinx.util.docutils import SphinxTranslator
+from sphinx.util.nodes import make_refnode
+
+from . import summary
+from .parse import parse
+
+logger = logging.getLogger(__name__)
+
+global_macros = {
+    "html": (
+        """
+        {% macro make_permalink(identifier, type) %}
+            {% if node.ids and translator.config.html_permalinks %}
+                {% if  translator.builder.add_permalinks %}
+                    <a class="headerlink" href="#{{ identifier }}"
+                        title="Permalink to this {{ type }}">{{
+                            translator.config.html_permalinks_icon
+                    }}</a>
+                {% endif %}
+            {% endif %}
+        {% endmacro %}
+        """
+
+        """
+        {% macro node_source(node) %}
+            <details>
+                <summary>{{ node.ids[0] }} source code</summary>
+                <div class="highlight">
+                    <pre>{{ node.source_code }}</pre>
+                </div>
+                </summary>
+            </details>
+        {% endmacro %}
+        """
+
+        """
+        {% macro formatted_decl(decl) %}
+            {% if app.config.blark_signature_show_type %}
+                {% if decl.block == "OutputDeclarations" %}
+                    {{ decl.type }} <em>{{decl.name}} =&gt;</em>
+                {% else %}
+                    {{ decl.type }} <em>{{decl.name}}</em>
+                {% endif %}
+            {% else %}
+                {{ decl.name }}
+            {% endif %}
+        {% endmacro %}
+        """
+
+        """
+        {% macro render_declarations(node, declarations) %}
+            {% for block, decls in declarations.items() %}
+                <dl class="field-list">
+                {% if block == "InputDeclarations" %}
+                    {% set block_name = "VAR_INPUT" %}
+                {% elif block == "OutputDeclarations" %}
+                    {% set block_name = "VAR_OUTPUT" %}
+                {% elif block == "InputOutputDeclarations" %}
+                    {% set block_name = "VAR_INOUT" %}
+                {% elif block == "VariableDeclarations" %}
+                    {% set block_name = "VAR" %}
+                {% elif block == "MethodInstanceVariableDeclarations" %}
+                    {% set block_name = "VAR" %}
+                {% else %}
+                    {% set block_name = block %}
+                {% endif %}
+                <dt class="field-odd">{{ block_name }}</dt>
+                <dd class="field-odd">
+                    <dl class="{{ block_name | lower }}">
+                    {% for decl in decls.values() %}
+                        {% set qualified_name = node.name + "." + decl.name %}
+                        <dt id="{{ qualified_name }}">
+                            <span class="parameter">{{ decl.name }}</span>
+                            &nbsp;:&nbsp;
+                            <code class="typename">{{ decl.type }}</code>
+                            {{ make_permalink(qualified_name, "variable") }}
+                        </dt>
+                        <dd>
+                            {% if decl.value %}
+                                <span class="paraminfo">Default: <code>{{decl.value}}</code></span>
+                            {% endif %}
+                            {% for comment in decl.comments %}
+                                <span class="paraminfo">{{ comment | trim("/(*)") }}</span>
+                            {% endfor %}
+                            {% for pragma in decl.pragmas %}
+                            <span class="pragma"><pre>{{ pragma }}</pre></span>
+                            {% endfor %}
+                        </dd>
+                    {% endfor %}
+                    </dl>
+                </dd>
+                </dl>
+            {% endfor %}
+        {% endmacro %}
+        """
+    )
+}
+
+
+@dataclasses.dataclass
+class BlarkSphinxCache:
+    cache: Dict[str, summary.CodeSummary] = dataclasses.field(default_factory=dict)
+    _instance_: ClassVar[BlarkSphinxCache]
+
+    @staticmethod
+    def instance():
+        if not hasattr(BlarkSphinxCache, "_instance_"):
+            BlarkSphinxCache._instance_ = BlarkSphinxCache()
+        return BlarkSphinxCache._instance_
+
+    def find_by_name(self, name: str):
+        for item in self.cache.values():
+            try:
+                return item.function_blocks[name]
+            except KeyError:
+                ...
+        raise KeyError(f"{name!r} not found")
+
+    def configure(self, app: sphinx.application.Sphinx, config):
+        for filename in config.blark_projects:
+            logger.debug("Loading %s", filename)
+            for fn, info in parse(filename):
+                logger.debug("Parsed %s", fn)
+                self.cache[fn] = summary.CodeSummary.from_source(info)
+
+
+class BlarkDirective(ObjectDescription):
+    has_content = True
+    required_arguments = 1
+    optional_arguments = 0
+    final_argument_whitespace = True
+    doc_field_types = []
+
+    def run(self):
+        if ":" in self.name:
+            self.domain, self.objtype = self.name.split(":", 1)
+        else:
+            self.domain, self.objtype = "", self.name
+
+        obj_name = self.parse_arguments()
+        scope = self.env.ref_context.get("bk:scope", [])
+        docname = self.env.docname
+        domaindata = self.env.domaindata["bk"]
+        try:
+            obj = BlarkSphinxCache.instance().find_by_name(obj_name)
+        except KeyError:
+            logger.error("Could not find: %s", obj_name)
+            return []
+
+        node = FunctionBlockNode.from_fb(obj)
+        node.register(docname, scope, domaindata)
+        DocFieldTransformer(self).transform_all(node)
+        return [node]
+
+    def parse_arguments(self):
+        return self.arguments[0]
+
+    def parse_content(self, modelnode):
+        self.state.nested_parse(self.content, self.content_offset, modelnode)
+
+
+# class Module(BlarkDirective):
+#     final_argument_whitespace = False
+#
+#     def parse_content(self, modelnode):
+#         if "bk:scope" not in self.env.ref_context:
+#             self.env.ref_context["bk:scope"] = []
+#         self.env.ref_context["bk:scope"].append(modelnode.name)
+#         super().parse_content(modelnode)
+#         self.env.ref_context["bk:scope"].pop()
+
+
+class FunctionBlock(BlarkDirective):
+    doc_field_types = [
+        TypedField(
+            "parameter",
+            label=l_("Parameters"),
+            names=("param", "parameter", "arg", "argument"),
+            typerolename="obj",
+            typenames=("paramtype", "type"),
+            can_collapse=True,
+        ),
+        # Field(
+        #     "returntype",
+        #     label=l_("Return type"),
+        #     has_arg=False,
+        #     names=("rtype",),
+        #     bodyrolename="obj",
+        # ),
+    ]
+
+
+# class Type(BlarkDirective):
+#     pass
+
+
+class BlarkXRefRole(XRefRole):
+    def process_link(self, env, refnode, has_explicit_title, title, target):
+        refnode["bk:scope"] = list(env.ref_context.get("bk:scope", []))
+        if not has_explicit_title:
+            title = title.lstrip(".")  # only has a meaning for the target
+            target = target.lstrip("~")  # only has a meaning for the title
+            # if the first character is a tilde, don't display the module/class
+            # parts of the contents
+            if title[0:1] == "~":
+                title = title[1:]
+                dot = title.rfind(".")
+                if dot != -1:
+                    title = title[dot + 1:]
+        return title, target
+
+
+class BlarkDomain(Domain):
+    """
+    Blark IEC61131-3 language domain.
+    """
+    name = "bk"
+    label = "Blark"
+    object_types = {
+        "functionblock": ObjType(l_("functionblock"), l_("func"), l_("fb")),
+        "type": ObjType(l_("type"), "type"),
+        "module": ObjType(l_("module"), "mod"),
+        "parameter": ObjType(l_("parameter"), "parameter"),
+    }
+
+    directives = {
+        "functionblock": FunctionBlock,
+        # "type": Type,
+        # "module": Module,
+    }
+
+    roles = {
+        "functionblock": BlarkXRefRole(fix_parens=False),
+        "fb": BlarkXRefRole(fix_parens=False),
+        "parameter": BlarkXRefRole(),
+        "type": BlarkXRefRole(),
+        "mod": BlarkXRefRole(),
+    }
+
+    initial_data = {
+        # name -> [{docname, scope, qualified_name}, ...]
+        "module": {},
+        "type": {},
+        # name -> [{docname, scope, templateparameters, signature, qualified_name}]
+        "functionblock": {},
+        "parameter": {},
+        "method": {},
+    }
+    indices = [
+        # BlarkModuleIndex,
+    ]
+
+    def find_obj(self, rolename, node, targetstring):
+        for typename, objtype in self.object_types.items():
+            if rolename in objtype.roles:
+                break
+        else:
+            return []
+        # TODO: scoping?
+        # basescope = node["bk:scope"]
+        domaindata = self.env.domaindata["bk"][typename]
+        return domaindata.get(targetstring, [])
+
+    def resolve_xref(self, env, fromdocname, builder, typ, target, node, contnode):
+        matches = self.find_obj(typ, node, target)
+        if not matches:
+            logger.warning("No target found for cross-reference: %s", target)
+            return None
+        if len(matches) > 1:
+            logger.warning(
+                "More than one target found for cross-reference " "%r: %s",
+                target,
+                ", ".join(match["qualified_name"] for match in matches),
+            )
+        match = matches[0]
+        return make_refnode(
+            builder, fromdocname, match["docname"], match["qualified_name"],
+            contnode, target
+        )
+
+    def clear_doc(self, docname):
+        dictionaries = self.env.domaindata["bk"]
+        for dicname in self.initial_data.keys():
+            dictionary = dictionaries[dicname]
+            for name, methods in dictionary.items():
+                items_to_delete = []
+                for i, m in enumerate(methods):
+                    if m["docname"] == docname:
+                        items_to_delete.insert(0, i)
+                for i in items_to_delete:
+                    methods.pop(i)
+
+
+def setup(app: sphinx.application.Sphinx):
+    app.add_config_value('blark_projects', [], 'html')
+    app.add_config_value('blark_signature_show_type', True, 'html')
+
+    for cls in (FunctionBlockNode, ParameterNode, MethodNode):
+        app.add_node(
+            cls,
+            html=(
+                functools.partial(render_block, app, "html", 0),
+                functools.partial(render_block, app, "html", 1),
+            ),
+        )
+    app.add_domain(BlarkDomain)
+    app.connect("config-inited", BlarkSphinxCache.instance().configure)
+
+
+def render_block(
+    app: sphinx.application.Sphinx,
+    format: str,
+    template_index: int,
+    translator: SphinxTranslator,
+    node: nodes.Element,
+):
+    template = textwrap.dedent(node._jinja_format_[format][template_index])
+    if hasattr(node, "get_render_context"):
+        ctx = node.get_render_context(translator, format)
+    else:
+        ctx = {}
+    formatted = FormatContext().render_template(
+        global_macros.get(format, "") + template,
+        node=node,
+        translator=translator,
+        app=app,
+        **ctx
+    )
+    translator.body.append(formatted)
+
+
+pass_eval_context = (
+    jinja2.pass_eval_context
+    if hasattr(jinja2, "pass_eval_context")
+    else jinja2.evalcontextfilter
+)
+
+
+class FormatContext:
+    def __init__(
+        self, helpers=None, *, trim_blocks=True, lstrip_blocks=False, **env_kwargs
+    ):
+        self.helpers = helpers or [type, locals]
+        self.env = jinja2.Environment(
+            trim_blocks=trim_blocks,
+            lstrip_blocks=lstrip_blocks,
+            **env_kwargs,
+        )
+
+        self.env.filters.update(self.get_filters())
+        self.default_render_context = self.get_render_context()
+
+    def get_filters(self, **user_config):
+        """Default jinja filters for all contexts."""
+
+        @pass_eval_context
+        def title_fill(eval_ctx, text, fill_char):
+            return fill_char * len(text)
+
+        @pass_eval_context
+        def classname(eval_ctx, obj):
+            if inspect.isclass(obj):
+                return obj.__name__
+            return type(obj).__name__
+
+        return {
+            key: value
+            for key, value in locals().items()
+            if not key.startswith("_") and key not in {"self"}
+        }
+
+    def render_template(self, _template: str, **context):
+        # TODO: want this to be positional-only; fallback here for pypy
+        template = _template
+
+        for key, value in self.default_render_context.items():
+            context.setdefault(key, value)
+        context["render_ctx"] = context
+        return self.env.from_string(template).render(context)
+
+    def get_render_context(self) -> dict:
+        """Jinja template context dictionary - helper functions."""
+        context = {func.__name__: func for func in self.helpers}
+        return context
+
+
+class BlarkNode(nodes.Element):
+    @property
+    def name(self):
+        return self["ids"][0].split(".")[-1]
+
+    @property
+    def qualified_name(self):
+        return self["ids"][0]
+
+    def register(self, docname, scope, domaindata):
+        item = {
+            "docname": docname,
+            "scope": list(scope),
+            "qualified_name": self.qualified_name,
+        }
+
+        # domaindata.setdefault(self.name, []).append(item)
+        # if self.qualified_name != self.name:
+        domaindata[self.objtype].setdefault(self.qualified_name, []).append(item)
+
+
+class ParameterNode(BlarkNode):
+    objtype: str = "parameter"
+    _jinja_format_ = {
+        "html": ("", ""),
+    }
+
+    @classmethod
+    def from_decl(
+        cls, owner: summary.FunctionBlockSummary, decl: summary.DeclarationSummary
+    ) -> ParameterNode:
+        return cls(
+            name=decl.name,
+            owner=owner,
+            decl=decl,
+            ids=[f"{owner.name}.{decl.name}"],
+        )
+
+
+class ElementWithDeclarations(BlarkNode):
+    def get_render_context(self, translator: SphinxTranslator, format: str):
+        decls = self["declarations"]
+        inputs = dict(decls.get("InputDeclarations", {}))
+        inputs.update(decls.get("InputOutputDeclarations", {}))
+        outputs = decls.get("OutputDeclarations", {})
+        return dict(
+            inputs=list(inputs.values()),
+            outputs=list(outputs.values()),
+        )
+
+    def register(self, docname, scope, domaindata):
+        super().register(docname, scope, domaindata)
+        for child in self.children:
+            if isinstance(child, BlarkNode):
+                child.register(docname, scope, domaindata)
+
+
+class MethodNode(ElementWithDeclarations):
+    objtype: str = "method"
+
+    _jinja_format_ = {
+        "html": (
+            """\
+            <dl class="function">
+                <dt id="{{ node.name }}">
+                    <span class="sig">
+                        <em class="property">METHOD</em>
+                        <code class="descname">
+                            {{ node.name }}
+                        </code>
+                        {% set formatted_decls = [] %}
+                        {% for decl in inputs + outputs %}
+                            {% set _ = formatted_decls.append(formatted_decl(decl)) %}
+                        {% endfor %}
+                        <span class="sig-paren">(</span>{{
+                            formatted_decls | join(", ")
+                        }}<span class="sig-paren">)</span>
+
+                        {{ make_permalink(node.name, "function block") }}
+                        </dt>
+                    </span>
+                    <dd>
+                    {% if node.declarations %}
+                        {{ render_declarations(node, node.declarations) }}
+                    {% endif %}
+                    </dd>
+                    {{ node_source(node) }}
+            """,
+
+            """\
+            </dd></dl>
+            """
+        )
+    }
+
+    @classmethod
+    def from_method(
+        cls, fb: summary.FunctionBlockSummary, method: summary.MethodSummary
+    ) -> MethodNode:
+        children = [
+            ParameterNode.from_decl(fb, decl)
+            for block, decls in method.declarations_by_block.items()
+            for decl in decls.values()
+        ]
+        return cls(
+            *children,
+            name=method.name,
+            ids=[f"{fb.name}.{method.name}"],
+            declarations=method.declarations_by_block,
+            source_code=method.source_code,
+        )
+
+
+class FunctionBlockNode(ElementWithDeclarations):
+    objtype: str = "functionblock"
+
+    _jinja_format_ = {
+        "html": (
+            """\
+            <dl class="function">
+                <dt id="{{ node.name }}">
+                    <span class="sig">
+                        <em class="property">FUNCTION_BLOCK</em>
+                        <code class="descname">
+                            {{ node.name }}
+                        </code>
+                        {% set formatted_decls = [] %}
+                        {% for decl in inputs + outputs %}
+                            {% set _ = formatted_decls.append(formatted_decl(decl)) %}
+                        {% endfor %}
+                        <span class="sig-paren">(</span>{{
+                            formatted_decls | join(", ")
+                        }}<span class="sig-paren">)</span>
+
+                        {{ make_permalink(node.name, "function block") }}
+                        </dt>
+                    </span>
+                    <dd>
+                    {% if node.declarations %}
+                        {{ render_declarations(node, node.declarations) }}
+                    {% endif %}
+                    </dd>
+                    {{ node_source(node) }}
+            """,
+
+            """\
+            </dd></dl>
+            """
+        )
+    }
+
+    @classmethod
+    def from_fb(cls, fb: summary.FunctionBlockSummary) -> FunctionBlockNode:
+        children = [
+            ParameterNode.from_decl(fb, decl)
+            for block, decls in fb.declarations_by_block.items()
+            for decl in decls.values()
+        ]
+        # children.extend(
+        #     [ActionNode.from_action(fb, action) for action in fb.actions]
+        # )
+        children.extend(
+            [MethodNode.from_method(fb, method) for method in fb.methods]
+        )
+        return cls(
+            *children,
+            name=fb.name,
+            ids=[fb.name],
+            declarations=fb.declarations_by_block,
+            source_code=fb.source_code,
+        )

--- a/blark/summary.py
+++ b/blark/summary.py
@@ -88,6 +88,18 @@ class DeclarationSummary(Summary):
     type: str
     value: Optional[str]
 
+    @property
+    def location_type(self) -> Optional[str]:
+        if not self.location:
+            return None
+
+        location = self.location.upper()
+        if location.startswith("AT %I"):
+            return "input"
+        if location.startswith("AT %Q"):
+            return "output"
+        return None
+
     @classmethod
     def from_declaration(
         cls, item: tf.InitDeclaration, block_header: str = "unknown"

--- a/blark/summary.py
+++ b/blark/summary.py
@@ -131,11 +131,11 @@ class DeclarationSummary(Summary):
             return None
 
         location = self.location.upper()
-        if location.startswith("AT %I"):
+        if location.startswith("%I"):
             return "input"
-        if location.startswith("AT %Q"):
+        if location.startswith("%Q"):
             return "output"
-        if location.startswith("AT %M"):
+        if location.startswith("%M"):
             return "memory"
         return None
 
@@ -154,12 +154,15 @@ class DeclarationSummary(Summary):
             spec = item.init
             spec = getattr(spec, "name", spec)
 
-        if isinstance(spec, str):
+        if isinstance(spec, (str, tf.SimpleVariable)):  # TODO
             base_type = str(spec)
         elif hasattr(spec, "type_name"):
             base_type = str(spec.type_name)
         elif hasattr(spec, "type"):
-            base_type = spec.type.type_name
+            if hasattr(spec.type, "type_name"):
+                base_type = spec.type.type_name
+            else:
+                base_type = str(spec.type)
         else:
             raise ValueError(f"TODO: {type(spec)}")
 
@@ -173,7 +176,7 @@ class DeclarationSummary(Summary):
             location = getattr(var, "location", None)
             result[name] = DeclarationSummary(
                 name=str(name),
-                location=str(location) if location else None,
+                location=str(location).replace("AT ", "") if location else None,
                 block=block_header,
                 type=str(spec),
                 base_type=base_type,

--- a/blark/summary.py
+++ b/blark/summary.py
@@ -8,17 +8,34 @@ from typing import Any, Dict, Iterable, List, Optional, Union
 from . import transform as tf
 
 
-def _indented_outline(text: Optional[str]) -> Optional[str]:
-    text = text_outline(text)
+def _indented_outline(item: Any, indent: str = "    ") -> Optional[str]:
+    """Outline and indent the given item."""
+    text = text_outline(item)
     if text is None:
         return None
-    result = textwrap.indent(text, "    ")
+    result = textwrap.indent(text, indent)
     if "\n" in result:
         return "\n" + result
     return result.lstrip()
 
 
-def text_outline(item):
+def text_outline(item: Any) -> Optional[str]:
+    """
+    Get a generic multiline string representation of the given object.
+
+    Attempts to include field information for dataclasses, put list items
+    on separate lines, and generally keep sensible indentation.
+
+    Parameters
+    ----------
+    item : Any
+        The item to outline.
+
+    Returns
+    -------
+    formatted : str or None
+        The formatted result.
+    """
     if item is None:
         return None
 
@@ -57,6 +74,7 @@ def text_outline(item):
 
 @dataclass
 class Summary:
+    """Base class for summary objects."""
     comments: List[str]
     pragmas: List[str]
     meta: Optional[tf.Meta] = field(repr=False)
@@ -90,6 +108,7 @@ else:
 
 @dataclass
 class DeclarationSummary(Summary):
+    """Summary representation of a single declaration."""
     name: str
     parent: str
     location: Optional[str]
@@ -180,6 +199,7 @@ class DeclarationSummary(Summary):
 
 @dataclass
 class ActionSummary(Summary):
+    """Summary representation of a single action."""
     name: str
     source_code: str
 
@@ -197,8 +217,9 @@ class ActionSummary(Summary):
 
 @dataclass
 class MethodSummary(Summary):
+    """Summary representation of a single method."""
     name: str
-    return_type: Optional[tf.LocatedVariableSpecInit]
+    return_type: Optional[str]
     source_code: str
     declarations: Dict[str, DeclarationSummary] = field(default_factory=dict)
 
@@ -216,7 +237,7 @@ class MethodSummary(Summary):
 
         summary = MethodSummary(
             name=method.name,
-            return_type=method.return_type,
+            return_type=str(method.return_type) if method.return_type else None,
             source_code=source_code,
             **Summary.get_meta_kwargs(method.meta),
         )
@@ -228,8 +249,9 @@ class MethodSummary(Summary):
 
 @dataclass
 class FunctionSummary(Summary):
+    """Summary representation of a single function."""
     name: str
-    return_type: str
+    return_type: Optional[str]
     source_code: str
     declarations: Dict[str, DeclarationSummary] = field(default_factory=dict)
 
@@ -249,7 +271,7 @@ class FunctionSummary(Summary):
 
         summary = FunctionSummary(
             name=func.name,
-            return_type=str(func.return_type),
+            return_type=str(func.return_type) if func.return_type else None,
             source_code=source_code,
             **Summary.get_meta_kwargs(func.meta),
         )
@@ -262,6 +284,7 @@ class FunctionSummary(Summary):
 
 @dataclass
 class FunctionBlockSummary(Summary):
+    """Summary representation of a single function block."""
     name: str
     source_code: str
     declarations: Dict[str, DeclarationSummary] = field(default_factory=dict)
@@ -296,6 +319,7 @@ class FunctionBlockSummary(Summary):
 
 @dataclass
 class CodeSummary:
+    """Summary representation of a set of code - functions, function blocks, etc."""
     functions: Dict[str, FunctionSummary] = field(default_factory=dict)
     function_blocks: Dict[str, FunctionBlockSummary] = field(
         default_factory=dict

--- a/blark/summary.py
+++ b/blark/summary.py
@@ -1,62 +1,177 @@
 from __future__ import annotations
 
-from dataclasses import dataclass, field
-from typing import Dict, List, Union
+import textwrap
+from dataclasses import dataclass, field, fields, is_dataclass
+from typing import Any, Dict, List, Optional, Union
 
 from . import transform as tf
 
 
+def _indented_outline(text: Optional[str]) -> Optional[str]:
+    text = text_outline(text)
+    if text is None:
+        return None
+    result = textwrap.indent(text, "    ")
+    if "\n" in result:
+        return "\n" + result
+    return result.lstrip()
+
+
+def text_outline(item):
+    if item is None:
+        return None
+
+    if is_dataclass(item):
+        result = []
+        for fld in fields(item):
+            if fld.name in ("meta", ):
+                continue
+            value = _indented_outline(getattr(item, fld.name, None))
+            if value is not None:
+                result.append(f"{fld.name}: {value}")
+        if not result:
+            return None
+        return "\n".join(result)
+
+    if isinstance(item, (list, tuple)):
+        result = []
+        for value in item:
+            value = _indented_outline(value)
+            if value is not None:
+                result.append(f"- {value.lstrip()}")
+        if not result:
+            return None
+        return "\n".join(result)
+
+    if isinstance(item, dict):
+        result = []
+        for key, value in item.items():
+            value = _indented_outline(value)
+            if value is not None:
+                result.append(f"- {key}: {value}")
+        return "\n".join(result)
+
+    return str(item)
+
+
 @dataclass
-class Declaration:
+class Summary:
+    comments: List[str]
+    pragmas: List[str]
+    meta: Optional[tf.Meta] = field(repr=False)
+
+    def __str__(self) -> str:
+        return text_outline(self)
+
+    @staticmethod
+    def get_meta_kwargs(meta: Optional[tf.Meta]) -> Dict[str, Any]:
+        if meta is None:
+            return dict(
+                comments=[],
+                pragmas=[],
+                meta=None,
+            )
+
+        comments, pragmas = meta.get_comments_and_pragmas()
+        return dict(
+            comments=comments,
+            pragmas=pragmas,
+            meta=meta,
+        )
+
+
+@dataclass
+class DeclarationSummary(Summary):
     name: str
-    location: str
+    location: Optional[str]
     block: str
     type: str
     value: str
-    comments: List[str]
-    pragmas: List[str]
+
+    @classmethod
+    def from_declaration(
+        cls, item: tf.InitDeclaration, block_type: str = "unknown"
+    ) -> Dict[str, DeclarationSummary]:
+        result = {}
+        # OK, a bit lazy for now
+        try:
+            spec = item.init.spec
+        except AttributeError:
+            spec = "?"
+
+        try:
+            value = item.init.value
+        except AttributeError:
+            value = ""
+
+        for var in item.variables:
+            name = getattr(var, "name", var)
+            location = getattr(var, "location", None)
+            result[name] = DeclarationSummary(
+                name=str(name),
+                location=str(location) if location else None,
+                block=block_type,
+                type=str(spec),
+                value=value,
+                **Summary.get_meta_kwargs(item.meta),
+            )
+        return result
+
+    @classmethod
+    def from_block(
+        cls, block: tf.VariableDeclarationBlock
+    ) -> Dict[str, DeclarationSummary]:
+        result = {}
+        for decl in block.items:
+            result.update(cls.from_declaration(decl, block_type=type(decl).__name__))
+        return result
 
 
 @dataclass
-class FunctionBlockSummary:
+class ActionSummary(Summary):
     name: str
-    comments: List[str] = field(default_factory=list)
-    declarations: Dict[str, Declaration] = field(default_factory=dict)
-    # actions:
-    # methods:
+
+    @classmethod
+    def from_action(cls, action: tf.Action) -> ActionSummary:
+        return ActionSummary(
+            name=str(action.name),
+            **Summary.get_meta_kwargs(action.meta),
+        )
+
+
+@dataclass
+class MethodSummary(Summary):
+    return_type: Optional[tf.LocatedVariableSpecInit]
+    declarations: Dict[str, DeclarationSummary] = field(default_factory=dict)
+
+    @classmethod
+    def from_method(cls, method: tf.Method) -> MethodSummary:
+        summary = MethodSummary(
+            return_type=method.return_type,
+            **Summary.get_meta_kwargs(method.meta),
+        )
+        for decl in method.declarations:
+            summary.declarations.update(DeclarationSummary.from_block(decl))
+
+        return summary
+
+
+@dataclass
+class FunctionBlockSummary(Summary):
+    name: str
+    declarations: Dict[str, DeclarationSummary] = field(default_factory=dict)
+    actions: List[ActionSummary] = field(default_factory=list)
+    methods: List[MethodSummary] = field(default_factory=list)
 
     @classmethod
     def from_function_block(cls, fb: tf.FunctionBlock) -> FunctionBlockSummary:
         summary = FunctionBlockSummary(
-            name=fb.name, comments=fb.meta.comments if fb.meta else None
+            name=fb.name,
+            **Summary.get_meta_kwargs(fb.meta),
         )
 
         for decl in fb.declarations:
-            for item in decl.items:
-                # OK, a bit lazy for now
-                try:
-                    spec = item.init.spec
-                except AttributeError:
-                    spec = "?"
-
-                try:
-                    value = item.init.value
-                except AttributeError:
-                    value = ""
-
-                for var in item.variables:
-                    name = getattr(var, "name", var)
-                    location = getattr(var, "location", None)
-                    comments, pragmas = item.meta.get_comments_and_pragmas()
-                    summary.declarations[name] = Declaration(
-                        name=name,
-                        location=location,
-                        block=type(decl).__name__,
-                        type=str(spec),
-                        value=value,
-                        comments=comments,
-                        pragmas=pragmas,
-                    )
+            summary.declarations.update(DeclarationSummary.from_block(decl))
 
         return summary
 
@@ -67,6 +182,12 @@ class CodeSummary:
         default_factory=dict
     )
 
+    def __str__(self):
+        return "\n".join(
+            f"{name}:\n{fb}"
+            for name, fb in self.function_blocks.items()
+        )
+
     @staticmethod
     def from_source(code: Union[tf.SourceCode, tf.SourceCodeItem]) -> CodeSummary:
         result = CodeSummary()
@@ -75,7 +196,20 @@ class CodeSummary:
         else:
             items = [code]
 
+        last_function_block = None
         for item in items:
             if isinstance(item, tf.FunctionBlock):
-                result.function_blocks[item.name] = FunctionBlockSummary.from_function_block(item)
+                summary = FunctionBlockSummary.from_function_block(item)
+                result.function_blocks[item.name] = summary
+                last_function_block = summary
+            elif isinstance(item, tf.Method):
+                if last_function_block is not None:
+                    last_function_block.methods.append(
+                        MethodSummary.from_method(item)
+                    )
+            elif isinstance(item, tf.Action):
+                if last_function_block is not None:
+                    last_function_block.actions.append(
+                        ActionSummary.from_action(item)
+                    )
         return result

--- a/blark/summary.py
+++ b/blark/summary.py
@@ -324,7 +324,7 @@ class FunctionBlockSummary(Summary):
 
 @dataclass
 class DataTypeSummary(Summary):
-    """Summary representation of a single function block."""
+    """Summary representation of a single data type."""
     name: str
     source_code: str
     type: str
@@ -402,12 +402,12 @@ class CodeSummary:
                 result.functions[item.name] = summary
                 last_function_block = None
             elif isinstance(item, tf.DataTypeDeclaration):
-                for subitem in item.items:
+                if isinstance(item.declaration, tf.StructureTypeDeclaration):
                     summary = DataTypeSummary.from_data_type(
-                        subitem,
-                        source_code=get_code_by_meta(subitem.meta)
+                        item.declaration,
+                        source_code=get_code_by_meta(item.declaration.meta)
                     )
-                    result.data_types[subitem.name] = summary
+                    result.data_types[item.declaration.name] = summary
                 last_function_block = None
             elif isinstance(item, tf.Method):
                 if last_function_block is not None:

--- a/blark/summary.py
+++ b/blark/summary.py
@@ -131,11 +131,16 @@ class DeclarationSummary(Summary):
 @dataclass
 class ActionSummary(Summary):
     name: str
+    source_code: str
 
     @classmethod
-    def from_action(cls, action: tf.Action) -> ActionSummary:
+    def from_action(cls, action: tf.Action, source_code: Optional[str] = None) -> ActionSummary:
+        if source_code is None:
+            source_code = str(action)
+
         return ActionSummary(
             name=str(action.name),
+            source_code=source_code,
             **Summary.get_meta_kwargs(action.meta),
         )
 
@@ -248,6 +253,9 @@ class CodeSummary:
             elif isinstance(item, tf.Action):
                 if last_function_block is not None:
                     last_function_block.actions.append(
-                        ActionSummary.from_action(item)
+                        ActionSummary.from_action(
+                            item,
+                            source_code=get_code_by_meta(item.meta)
+                        )
                     )
         return result

--- a/blark/summary.py
+++ b/blark/summary.py
@@ -17,7 +17,8 @@ def _get_comments_and_pragmas(item):
     try:
         all_comments = item.meta.comments
     except AttributeError:
-        return []
+        return [], []
+
     pragmas = []
     comments = []
     by_type = {

--- a/blark/summary.py
+++ b/blark/summary.py
@@ -325,6 +325,7 @@ class FunctionBlockSummary(Summary):
 @dataclass
 class DataTypeSummary(Summary):
     """Summary representation of a single data type."""
+    # Note: structures only for now.
     name: str
     source_code: str
     type: str

--- a/blark/summary.py
+++ b/blark/summary.py
@@ -6,13 +6,6 @@ from typing import Dict, List, Union
 from . import transform as tf
 
 
-def _get_comments(item):
-    try:
-        return item.meta.comments
-    except AttributeError:
-        return []
-
-
 @dataclass
 class Declaration:
     name: str
@@ -34,7 +27,9 @@ class FunctionBlockSummary:
 
     @classmethod
     def from_function_block(cls, fb: tf.FunctionBlock) -> FunctionBlockSummary:
-        summary = FunctionBlockSummary(name=fb.name, comments=_get_comments(fb))
+        summary = FunctionBlockSummary(
+            name=fb.name, comments=fb.meta.comments if fb.meta else None
+        )
 
         for decl in fb.declarations:
             for item in decl.items:

--- a/blark/summary.py
+++ b/blark/summary.py
@@ -13,26 +13,6 @@ def _get_comments(item):
         return []
 
 
-def _get_comments_and_pragmas(item):
-    try:
-        all_comments = item.meta.comments
-    except AttributeError:
-        return [], []
-
-    pragmas = []
-    comments = []
-    by_type = {
-        "SINGLE_LINE_COMMENT": comments,
-        "MULTI_LINE_COMMENT": comments,
-        "PRAGMA": pragmas,
-    }
-
-    for comment in all_comments:
-        by_type[comment.type].append(comment)
-
-    return pragmas, comments
-
-
 @dataclass
 class Declaration:
     name: str
@@ -72,7 +52,7 @@ class FunctionBlockSummary:
                 for var in item.variables:
                     name = getattr(var, "name", var)
                     location = getattr(var, "location", None)
-                    comments, pragmas = _get_comments_and_pragmas(item)
+                    comments, pragmas = item.meta.get_comments_and_pragmas()
                     summary.declarations[name] = Declaration(
                         name=name,
                         location=location,

--- a/blark/summary.py
+++ b/blark/summary.py
@@ -1,0 +1,105 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Dict, List, Union
+
+from . import transform as tf
+
+
+def _get_comments(item):
+    try:
+        return item.meta.comments
+    except AttributeError:
+        return []
+
+
+def _get_comments_and_pragmas(item):
+    try:
+        all_comments = item.meta.comments
+    except AttributeError:
+        return []
+    pragmas = []
+    comments = []
+    by_type = {
+        "SINGLE_LINE_COMMENT": comments,
+        "MULTI_LINE_COMMENT": comments,
+        "PRAGMA": pragmas,
+    }
+
+    for comment in all_comments:
+        by_type[comment.type].append(comment)
+
+    return pragmas, comments
+
+
+@dataclass
+class Declaration:
+    name: str
+    location: str
+    block: str
+    type: str
+    value: str
+    comments: List[str]
+    pragmas: List[str]
+
+
+@dataclass
+class FunctionBlockSummary:
+    name: str
+    comments: List[str] = field(default_factory=list)
+    declarations: Dict[str, Declaration] = field(default_factory=dict)
+    # actions:
+    # methods:
+
+    @classmethod
+    def from_function_block(cls, fb: tf.FunctionBlock) -> FunctionBlockSummary:
+        summary = FunctionBlockSummary(name=fb.name, comments=_get_comments(fb))
+
+        for decl in fb.declarations:
+            for item in decl.items:
+                # OK, a bit lazy for now
+                try:
+                    spec = item.init.spec
+                except AttributeError:
+                    spec = "?"
+
+                try:
+                    value = item.init.value
+                except AttributeError:
+                    value = ""
+
+                for var in item.variables:
+                    name = getattr(var, "name", var)
+                    location = getattr(var, "location", None)
+                    comments, pragmas = _get_comments_and_pragmas(item)
+                    summary.declarations[name] = Declaration(
+                        name=name,
+                        location=location,
+                        block=type(decl).__name__,
+                        type=str(spec),
+                        value=value,
+                        comments=comments,
+                        pragmas=pragmas,
+                    )
+
+        return summary
+
+
+@dataclass
+class CodeSummary:
+    function_blocks: Dict[str, FunctionBlockSummary] = field(
+        default_factory=dict
+    )
+
+    @staticmethod
+    def from_source(code: Union[tf.SourceCode, tf.SourceCodeItem]) -> CodeSummary:
+        result = CodeSummary()
+        if isinstance(code, tf.SourceCode):
+            items = code.items
+        else:
+            items = [code]
+
+        for item in items:
+            if isinstance(item, tf.FunctionBlock):
+                result.function_blocks[item.name] = FunctionBlockSummary.from_function_block(item)
+        return result

--- a/blark/tests/conftest.py
+++ b/blark/tests/conftest.py
@@ -1,9 +1,6 @@
-import dataclasses
 import functools
-import inspect
 import pathlib
 
-import lark
 import pytest
 
 from ..parse import new_parser
@@ -23,32 +20,3 @@ def get_grammar(*, start=None, **kwargs):
 @pytest.fixture(scope="module")
 def grammar():
     return get_grammar()
-
-
-def stringify_tokens(obj):
-    if obj is None:
-        return
-    if isinstance(obj, list):
-        return [stringify_tokens(part) for part in obj]
-    if isinstance(obj, tuple):
-        return tuple(stringify_tokens(part) for part in obj)
-    if isinstance(obj, dict):
-        return {
-            key: stringify_tokens(value)
-            for key, value in obj.items()
-        }
-
-    if isinstance(obj, lark.Token):
-        return str(obj)
-
-    if dataclasses.is_dataclass(obj):
-        for attr, item in inspect.getmembers(obj):
-            if attr.startswith("_"):
-                continue
-
-            try:
-                setattr(obj, attr, stringify_tokens(item))
-            except AttributeError:
-                ...
-
-    return obj

--- a/blark/tests/test_parsing.py
+++ b/blark/tests/test_parsing.py
@@ -2,7 +2,7 @@ import pathlib
 
 import pytest
 
-from ..parse import parse_single_file, summarize
+from ..parse import parse, summarize
 from .conftest import get_grammar
 
 TEST_PATH = pathlib.Path(__file__).parent
@@ -22,7 +22,7 @@ def pou_filename(request):
 
 def test_parsing(pou_filename):
     try:
-        result = parse_single_file(pou_filename, verbose=2)
+        ((fn, result),) = list(parse(pou_filename))
     except FileNotFoundError:
         pytest.skip(f"Missing file: {pou_filename}")
     else:

--- a/blark/tests/test_transformer.py
+++ b/blark/tests/test_transformer.py
@@ -488,6 +488,7 @@ def test_var_access_roundtrip(rule_name, value):
                 fbTest1 : FB_Test(1, 2);
                 fbTest2 : FB_Test(A := 1, B := 2);
                 fbTest3 : FB_TestC;
+                i_iFscEB1Ch0AI AT %I* : INT;
             END_VAR
             """
         )),

--- a/blark/tests/test_transformer.py
+++ b/blark/tests/test_transformer.py
@@ -845,6 +845,17 @@ def test_statement_roundtrip(rule_name, value):
             """),
             id="no_return_type",
         ),
+        param("function_declaration", tf.multiline_code_block(
+            """
+            FUNCTION FuncName : Tc2_System.T_MaxString
+                VAR_INPUT
+                    Ptr : POINTER TO UINT;
+                END_VAR
+                Ptr^ := 5;
+            END_FUNCTION
+            """),
+            id="dotted_return_type",
+        ),
     ],
 )
 def test_function_roundtrip(rule_name, value):

--- a/blark/tests/test_transformer.py
+++ b/blark/tests/test_transformer.py
@@ -807,6 +807,14 @@ def test_fb_roundtrip(rule_name, value):
             END_FOR
             """
         )),
+        param("for_statement", tf.multiline_code_block(
+            """
+            FOR iIndex[1] := 0 TO 10
+            DO
+                iValue := iIndex * 2;
+            END_FOR
+            """
+        )),
     ],
 )
 def test_statement_roundtrip(rule_name, value):

--- a/blark/tests/test_transformer.py
+++ b/blark/tests/test_transformer.py
@@ -990,7 +990,7 @@ def test_incomplete_located_var_decls(rule_name, value):
                 STRUCT
                     xPLC_CnBitsValid : BOOL;
                     xPLC_CnBits : ARRAY [0..20] OF BYTE;
-                END_STRUCT;
+                END_STRUCT
             END_TYPE
             """
         )),
@@ -1027,6 +1027,26 @@ def test_incomplete_located_var_decls(rule_name, value):
         param("data_type_declaration", tf.multiline_code_block(
             """
             TYPE EnumeratedTypeName : REFERENCE TO (IdentifierA, INT#IdentifierB := 1);
+            END_TYPE
+            """
+        )),
+        param("data_type_declaration", tf.multiline_code_block(
+            """
+            TYPE TypeName :
+                UNION
+                    intval : INT;
+                    as_bytes : ARRAY [0..2] OF BYTE;
+                END_UNION
+            END_TYPE
+            """
+        )),
+        param("data_type_declaration", tf.multiline_code_block(
+            """
+            TYPE TypeName :
+                UNION
+                    intval : INT;
+                    enum : (iValue := 1, iValue2 := 2) INT;
+                END_UNION
             END_TYPE
             """
         )),

--- a/blark/tests/test_transformer.py
+++ b/blark/tests/test_transformer.py
@@ -81,21 +81,21 @@ def test_check_unhandled_rules(grammar):
     [
         param("integer_literal", "-12", tf.Integer(value="-12")),
         param("integer_literal", "12", tf.Integer(value="12")),
-        param("integer_literal", "INT#12", tf.Integer(value="12", type="INT")),
+        param("integer_literal", "INT#12", tf.Integer(value="12", type_name="INT")),
         param("integer_literal", "2#10010", tf.BinaryInteger(value="10010")),
         param("integer_literal", "8#22", tf.OctalInteger(value="22")),
         param("integer_literal", "16#12", tf.HexInteger(value="12")),
-        param("integer_literal", "UDINT#12", tf.Integer(value="12", type="UDINT")),
-        param("integer_literal", "UDINT#2#010", tf.BinaryInteger(value="010", type="UDINT")),  # noqa: E501
-        param("integer_literal", "UDINT#2#1001_0011", tf.BinaryInteger(value="1001_0011", type="UDINT")),  # noqa: E501
-        param("integer_literal", "DINT#16#C0FFEE", tf.HexInteger(value="C0FFEE", type="DINT")),  # noqa: E501
+        param("integer_literal", "UDINT#12", tf.Integer(value="12", type_name="UDINT")),
+        param("integer_literal", "UDINT#2#010", tf.BinaryInteger(value="010", type_name="UDINT")),  # noqa: E501
+        param("integer_literal", "UDINT#2#1001_0011", tf.BinaryInteger(value="1001_0011", type_name="UDINT")),  # noqa: E501
+        param("integer_literal", "DINT#16#C0FFEE", tf.HexInteger(value="C0FFEE", type_name="DINT")),  # noqa: E501
         param("real_literal", "-12.0", tf.Real(value="-12.0")),
         param("real_literal", "12.0", tf.Real(value="12.0")),
         param("real_literal", "12.0e5", tf.Real(value="12.0e5")),
-        param("bit_string_literal", "WORD#1234", tf.BitString(type="WORD", value="1234")),
-        param("bit_string_literal", "WORD#2#0101", tf.BinaryBitString(type="WORD", value="0101")),  # noqa: E501
-        param("bit_string_literal", "WORD#8#777", tf.OctalBitString(type="WORD", value="777")),  # noqa: E501
-        param("bit_string_literal", "word#16#FEEE", tf.HexBitString(type="word", value="FEEE")),  # noqa: E501
+        param("bit_string_literal", "WORD#1234", tf.BitString(type_name="WORD", value="1234")),
+        param("bit_string_literal", "WORD#2#0101", tf.BinaryBitString(type_name="WORD", value="0101")),  # noqa: E501
+        param("bit_string_literal", "WORD#8#777", tf.OctalBitString(type_name="WORD", value="777")),  # noqa: E501
+        param("bit_string_literal", "word#16#FEEE", tf.HexBitString(type_name="word", value="FEEE")),  # noqa: E501
         param("duration", "TIME#-1D", tf.Duration(days="1", negative=True)),
         param("duration", "TIME#1D", tf.Duration(days="1")),
         param("duration", "TIME#10S", tf.Duration(seconds="10")),
@@ -811,8 +811,9 @@ def test_statement_roundtrip(rule_name, value):
                 END_VAR
                 FuncName := iValue;
             END_FUNCTION
-            """
-        )),
+            """),
+            id="int_with_input",
+        ),
         param("function_declaration", tf.multiline_code_block(
             """
             FUNCTION FuncName : INT
@@ -830,8 +831,20 @@ def test_statement_roundtrip(rule_name, value):
                 END_VAR
                 FuncName := iValue;
             END_FUNCTION
+            """),
+            id="int_with_input_output",
+          ),
+        param("function_declaration", tf.multiline_code_block(
             """
-        )),
+            FUNCTION FuncName
+                VAR_INPUT
+                    Ptr : POINTER TO UINT;
+                END_VAR
+                Ptr^ := 5;
+            END_FUNCTION
+            """),
+            id="no_return_type",
+        ),
     ],
 )
 def test_function_roundtrip(rule_name, value):

--- a/blark/tests/test_transformer.py
+++ b/blark/tests/test_transformer.py
@@ -510,6 +510,18 @@ def test_global_roundtrip(rule_name, value):
         )),
         param("function_block_type_declaration", tf.multiline_code_block(
             """
+            FUNCTION_BLOCK fbName IMPLEMENTS I_fbName
+            END_FUNCTION_BLOCK
+            """
+        )),
+        param("function_block_type_declaration", tf.multiline_code_block(
+            """
+            FUNCTION_BLOCK fbName IMPLEMENTS I_fbName, I_fbName2
+            END_FUNCTION_BLOCK
+            """
+        )),
+        param("function_block_type_declaration", tf.multiline_code_block(
+            """
             FUNCTION_BLOCK ABSTRACT fbName EXTENDS OtherFbName
             END_FUNCTION_BLOCK
             """

--- a/blark/tests/test_transformer.py
+++ b/blark/tests/test_transformer.py
@@ -45,7 +45,6 @@ def test_check_unhandled_rules(grammar):
         # handled as tree
         "global_var_list",
         "var_body",
-        "function_var_blocks",
 
     }
 

--- a/blark/tests/test_transformer.py
+++ b/blark/tests/test_transformer.py
@@ -231,6 +231,7 @@ def test_bool_literal_roundtrip(name, value, expected):
         param("array_type_declaration", "TypeName : ARRAY [1..2, 3..4] OF INT"),
         param("array_type_declaration", "TypeName : ARRAY [1..2] OF INT := [1, 2]"),
         param("array_type_declaration", "TypeName : ARRAY [1..2, 3..4] OF INT := [2(3), 3(4)]"),
+        param("array_type_declaration", "TypeName : ARRAY [1..2, 3..4] OF Tc.SomeType"),
         param("structure_type_declaration", "TypeName :\nSTRUCT\nEND_STRUCT"),
         param("structure_type_declaration", "TypeName EXTENDS Other.Type :\nSTRUCT\nEND_STRUCT"),
         param("structure_type_declaration", "TypeName : POINTER TO\nSTRUCT\nEND_STRUCT"),

--- a/blark/tests/test_transformer.py
+++ b/blark/tests/test_transformer.py
@@ -8,6 +8,13 @@ from .. import transform as tf
 from ..parse import parse_source_code
 from .conftest import get_grammar
 
+# try:
+#     import apischema
+# except ImportError:
+#     # apischema is optional for serialization testing
+#     apischema = None
+
+
 TEST_PATH = pathlib.Path(__file__).parent
 
 
@@ -868,6 +875,13 @@ def roundtrip_rule(rule_name: str, value: str, expected: Optional[str] = None):
     if expected is None:
         expected = value
     assert str(transformed) == expected
+
+    # if apischema is not None:
+    #     serialized = apischema.serialize(transformed)
+    #     print("serialized", serialized)
+    #     deserialized = apischema.deserialize(type(transformed), serialized)
+    #     print("deserialized", deserialized)
+    #     assert transformed == deserialized
     return transformed
 
 

--- a/blark/tests/test_util.py
+++ b/blark/tests/test_util.py
@@ -1,3 +1,5 @@
+import textwrap
+
 import pytest
 
 from ..parse import find_and_clean_comments
@@ -54,6 +56,9 @@ from ..parse import find_and_clean_comments
             *)
             """,
             id="nested_3",
+            marks=pytest.mark.xfail(
+                reason="Comments replaced OK; whitespace handling needs work"
+            )
         ),
         pytest.param(
             """
@@ -171,6 +176,6 @@ expected:
     if any(code.strip().startswith(c) for c in ['"', "'"]):
         expected_comments = []
     else:
-        expected_comments = [code.strip()]
+        expected_comments = [textwrap.dedent(code.lstrip("\n")).strip()]
     assert [str(comment) for comment in comments] == expected_comments
     print("comments=", comments)

--- a/blark/transform.py
+++ b/blark/transform.py
@@ -166,7 +166,6 @@ def meta_field():
     return dataclasses.field(default=None, repr=False, compare=False)
 
 
-@dataclasses.dataclass
 class Expression:
     ...
 
@@ -438,7 +437,6 @@ class String(Literal):
     meta: Optional[Meta] = meta_field()
 
 
-@dataclasses.dataclass
 class Variable(Expression):
     ...
 
@@ -625,7 +623,7 @@ class SubscriptList:
 @dataclass
 @_rule_handler("field_selector")
 class FieldSelector:
-    field: lark.Token
+    field: SymbolicVariable
     dereferenced: bool
     meta: Optional[Meta] = meta_field()
 
@@ -2886,14 +2884,18 @@ class InstructionList:
     def from_lark(
         *instructions: IL_Instruction
     ) -> Optional[InstructionList]:
-        if len(instructions) == 1 and instructions[0] == IL_Instruction(None, None):
-            # TODO: parser ambiguity; il_instruction can match an empty
-            # function block body with no label or operation....
-            return None
-
-        return InstructionList(
-            instructions=list(instructions)
-        )
+        # TODO: parser ambiguity; il_instruction can match an empty
+        # function block body with no label or operation....
+        instructions = [
+            instr
+            for instr in instructions
+            if instr.label is not None or instr.operation is not None
+        ]
+        if instructions:
+            return InstructionList(
+                instructions=list(instructions)
+            )
+        return None
 
     def __str__(self) -> str:
         return "\n".join(

--- a/blark/transform.py
+++ b/blark/transform.py
@@ -1497,12 +1497,13 @@ class FunctionBlock:
 
     @staticmethod
     def from_lark(
+        fb_token: lark.Token,
         abstract: Optional[lark.Token],
         derived_name: lark.Token,
         extends: Extends,
         *args
     ) -> FunctionBlock:
-        *declarations, body = args
+        *declarations, body, _ = args
         return FunctionBlock(
             name=derived_name,
             abstract=abstract is not None,

--- a/blark/transform.py
+++ b/blark/transform.py
@@ -1423,13 +1423,13 @@ class GlobalVariableSpec:
             name_tree = typing.cast(lark.Tree, name_or_names)
             variables = typing.cast(List[lark.Token], name_tree.children)
         else:
-            variables = typing.cast(List[lark.Token], name_or_names)
+            variables = typing.cast(List[lark.Token], [name_or_names])
         return GlobalVariableSpec(variables=variables, location=location)
 
     def __str__(self) -> str:
         if not self.location:
             return ", ".join(self.variables)
-        return f"{self.variables[0]} : {self.location}"
+        return f"{self.variables[0]} {self.location}"
 
 
 LocatedVariableSpecInit = Union[

--- a/blark/transform.py
+++ b/blark/transform.py
@@ -1775,6 +1775,7 @@ GlobalVariableDeclarationType = Union[
 
 
 class VariableDeclarationBlock:
+    block_header: ClassVar[str] = "VAR"
     items: List[Any]
     meta: Optional[Meta]
 
@@ -1782,6 +1783,7 @@ class VariableDeclarationBlock:
 @dataclass
 @_rule_handler("var_declarations", comments=True)
 class VariableDeclarations(VariableDeclarationBlock):
+    block_header: ClassVar[str] = "VAR"
     config: Optional[lark.Token]
     items: List[VariableInitDeclaration]
     meta: Optional[Meta] = meta_field()
@@ -1804,6 +1806,7 @@ class VariableDeclarations(VariableDeclarationBlock):
 @dataclass
 @_rule_handler("temp_var_decls", comments=True)
 class TemporaryVariableDeclarations(VariableDeclarationBlock):
+    block_header: ClassVar[str] = "VAR_TEMP"
     items: List[VariableInitDeclaration]
     meta: Optional[Meta] = meta_field()
 
@@ -1826,6 +1829,7 @@ class TemporaryVariableDeclarations(VariableDeclarationBlock):
 @dataclass
 @_rule_handler("var_inst_declaration", comments=True)
 class MethodInstanceVariableDeclarations(VariableDeclarationBlock):
+    block_header: ClassVar[str] = "VAR_INST"
     items: List[VariableInitDeclaration]
     meta: Optional[Meta] = meta_field()
 
@@ -1864,6 +1868,7 @@ class LocatedVariableDeclaration:
 @dataclass
 @_rule_handler("located_var_declarations", comments=True)
 class LocatedVariableDeclarations(VariableDeclarationBlock):
+    block_header: ClassVar[str] = "VAR"
     config: Optional[lark.Token]
     persistent: bool
     items: List[LocatedVariableDeclaration]
@@ -1921,6 +1926,7 @@ class IncompleteLocatedVariableDeclaration:
 @dataclass
 @_rule_handler("incomplete_located_var_declarations", comments=True)
 class IncompleteLocatedVariableDeclarations(VariableDeclarationBlock):
+    block_header: ClassVar[str] = "VAR"
     retain: bool
     items: List[IncompleteLocatedVariableDeclaration]
     meta: Optional[Meta] = meta_field()
@@ -1964,6 +1970,7 @@ class ExternalVariableDeclaration:
 @dataclass
 @_rule_handler("external_var_declarations", comments=True)
 class ExternalVariableDeclarations(VariableDeclarationBlock):
+    block_header: ClassVar[str] = "VAR_EXTERNAL"
     constant: bool
     items: List[ExternalVariableDeclaration]
     meta: Optional[Meta] = meta_field()
@@ -1991,6 +1998,7 @@ class ExternalVariableDeclarations(VariableDeclarationBlock):
 @dataclass
 @_rule_handler("input_declarations", comments=True)
 class InputDeclarations(VariableDeclarationBlock):
+    block_header: ClassVar[str] = "VAR_INPUT"
     retain: Optional[lark.Token]
     items: List[InputDeclaration]
     meta: Optional[Meta] = meta_field()
@@ -2012,6 +2020,7 @@ class InputDeclarations(VariableDeclarationBlock):
 @dataclass
 @_rule_handler("output_declarations", comments=True)
 class OutputDeclarations(VariableDeclarationBlock):
+    block_header: ClassVar[str] = "VAR_OUTPUT"
     retain: Optional[lark.Token]
     items: List[OutputDeclaration]
     meta: Optional[Meta] = meta_field()
@@ -2035,6 +2044,7 @@ class OutputDeclarations(VariableDeclarationBlock):
 @dataclass
 @_rule_handler("input_output_declarations", comments=True)
 class InputOutputDeclarations(VariableDeclarationBlock):
+    block_header: ClassVar[str] = "VAR_IN_OUT"
     items: List[InputOutputDeclaration]
     meta: Optional[Meta] = meta_field()
 
@@ -2074,6 +2084,7 @@ class AccessDeclaration:
 @dataclass
 @_rule_handler("function_var_declarations", comments=True)
 class FunctionVariableDeclarations(VariableDeclarationBlock):
+    block_header: ClassVar[str] = "VAR"
     constant: bool
     items: List[VariableInitDeclaration]
     meta: Optional[Meta] = meta_field()
@@ -2102,6 +2113,7 @@ class FunctionVariableDeclarations(VariableDeclarationBlock):
 @dataclass
 @_rule_handler("program_access_decls", comments=True)
 class AccessDeclarations(VariableDeclarationBlock):
+    block_header: ClassVar[str] = "VAR_ACCESS"
     items: List[AccessDeclaration]
     meta: Optional[Meta] = meta_field()
 
@@ -2122,6 +2134,7 @@ class AccessDeclarations(VariableDeclarationBlock):
 @dataclass
 @_rule_handler("global_var_declarations", comments=True)
 class GlobalVariableDeclarations(VariableDeclarationBlock):
+    block_header: ClassVar[str] = "VAR_GLOBAL"
     constant: bool
     retain: bool
     persistent: bool
@@ -2930,6 +2943,7 @@ class InstructionList:
 @dataclass
 @_rule_handler("config_access_declarations", comments=True)
 class ConfigAccessDeclarations(VariableDeclarationBlock):
+    block_header: ClassVar[str] = "VAR_ACCESS"
     items: List[ConfigAccessDeclaration]
     meta: Optional[Meta] = meta_field()
 

--- a/blark/transform.py
+++ b/blark/transform.py
@@ -3175,8 +3175,11 @@ class GrammarTransformer(lark.visitors.Transformer_InPlaceRecursive):
         if self.comments:
             merge_comments(transformed, self.comments)
         if isinstance(transformed, SourceCode):
-            transformed.source_code = self._source_code
-            transformed.filename = self._filename
+            transformed.raw_source = self._source_code
+            transformed.filename = (
+                pathlib.Path(self._filename)
+                if self._filename is not None else None
+            )
         return transformed
 
     @_annotator_method_wrapper

--- a/blark/transform.py
+++ b/blark/transform.py
@@ -629,7 +629,7 @@ class FieldSelector:
     meta: Optional[Meta] = meta_field()
 
     @staticmethod
-    def from_lark(dereferenced: Optional[lark.Token], field: lark.Token):
+    def from_lark(dereferenced: Optional[lark.Token], field: SymbolicVariable):
         return FieldSelector(
             field=field,
             dereferenced=dereferenced is not None

--- a/blark/transform.py
+++ b/blark/transform.py
@@ -142,8 +142,8 @@ class Meta:
 
         Returns
         -------
-        pragmas : List[lark.Token]
         comments : List[lark.Token]
+        pragmas : List[lark.Token]
         """
         if not self.comments:
             return [], []
@@ -159,7 +159,7 @@ class Meta:
         for comment in self.comments:
             by_type[comment.type].append(comment)
 
-        return pragmas, comments
+        return comments, pragmas
 
 
 def meta_field():
@@ -675,6 +675,19 @@ class TypeInitialization:
     def __str__(self) -> str:
         type_ = join_if(self.indirection, " ", self.spec)
         return join_if(type_, " := ", self.value)
+
+
+class Declaration:
+    variables: List[DeclaredVariable]
+    items: List[Any]
+    meta: Optional[Meta]
+    init: Union[
+        VariableInitDeclaration,
+        InputOutputDeclaration,
+        OutputDeclaration,
+        InputDeclaration,
+        GlobalVariableDeclarationType,
+    ]
 
 
 @dataclass
@@ -1233,6 +1246,7 @@ class DeclaredVariable:
 class InitDeclaration:
     variables: List[DeclaredVariable]
     init: Any
+    meta: Optional[Meta]
 
     def __str__(self) -> str:
         variables = ", ".join(str(variable) for variable in self.variables)
@@ -1589,7 +1603,9 @@ class Program:
 
 
 class Action:
-    ...
+    name: Union[str, lark.Token]
+    body: Optional[FunctionBody]
+    meta: Optional[Meta]
 
 
 @dataclass
@@ -1617,6 +1633,10 @@ class EntryAction(Action):
     body: Optional[FunctionBody]
     meta: Optional[Meta] = meta_field()
 
+    @property
+    def name(self) -> str:
+        return "ENTRY_ACTION"
+
     def __str__(self) -> str:
         return "\n".join(
             line for line in
@@ -1634,6 +1654,10 @@ class EntryAction(Action):
 class ExitAction(Action):
     body: Optional[FunctionBody]
     meta: Optional[Meta] = meta_field()
+
+    @property
+    def name(self) -> str:
+        return "EXIT_ACTION"
 
     def __str__(self) -> str:
         return "\n".join(
@@ -1734,7 +1758,7 @@ VariableInitDeclaration = Union[
     StringVariableInitDeclaration,
     VariableOneInitDeclaration,
     FunctionBlockDeclaration,
-    # EdgeDeclaration,
+    EdgeDeclaration,
 ]
 
 InputOutputDeclaration = VariableInitDeclaration
@@ -1748,13 +1772,11 @@ GlobalVariableDeclarationType = Union[
     VariableInitDeclaration,
     GlobalVariableDeclaration,
 ]
-# FunctionBlockDeclarations = Union[
-#     ...
-# ]
 
 
 class VariableDeclarationBlock:
-    ...
+    items: List[Any]
+    meta: Optional[Meta]
 
 
 @dataclass

--- a/blark/transform.py
+++ b/blark/transform.py
@@ -1043,6 +1043,11 @@ class StructureElementDeclaration:
     ]
     meta: Optional[Meta] = meta_field()
 
+    @property
+    def variables(self) -> List[str]:
+        """API compat"""
+        return [self.name]
+
     def __str__(self) -> str:
         name_and_location = join_if(self.name, " ", self.location)
         return f"{name_and_location} : {self.init};"

--- a/blark/transform.py
+++ b/blark/transform.py
@@ -2485,7 +2485,7 @@ class RepeatStatement(Statement):
 @dataclass
 @_rule_handler("for_statement", comments=True)
 class ForStatement(Statement):
-    control: lark.Token
+    control: SymbolicVariable
     from_: Expression
     to: Expression
     step: Optional[Expression]

--- a/blark/transform.py
+++ b/blark/transform.py
@@ -3128,23 +3128,22 @@ TypeDeclarationItem = Union[
 @dataclass
 @_rule_handler("data_type_declaration", comments=True)
 class DataTypeDeclaration:
-    items: List[TypeDeclarationItem]
+    declaration: Optional[TypeDeclarationItem]
     meta: Optional[Meta] = meta_field()
 
     @staticmethod
-    def from_lark(*args: TypeDeclarationItem) -> DataTypeDeclaration:
-        return DataTypeDeclaration(list(args))
+    def from_lark(
+        declaration: Optional[TypeDeclarationItem] = None,
+    ) -> DataTypeDeclaration:
+        return DataTypeDeclaration(declaration)
 
     def __str__(self) -> str:
-        if not self.items:
+        if not self.declaration:
             return "TYPE\nEND_TYPE"
 
-        items = "\n".join(
-            indent(f"{item};") for item in self.items
-        )
         return "\n".join(
             (
-                f"TYPE {items.lstrip()}",
+                "TYPE " + indent(f"{self.declaration};").lstrip(),
                 "END_TYPE",
             )
         )

--- a/blark/util.py
+++ b/blark/util.py
@@ -1,11 +1,12 @@
 import pathlib
 import re
-from typing import Generator, List, Tuple
+from typing import Generator, List, Tuple, Union
 
 import lark
 import pytmc
 
 RE_LEADING_WHITESPACE = re.compile('^[ \t]+', re.MULTILINE)
+AnyPath = Union[str, pathlib.Path]
 
 
 def get_source_code(fn):

--- a/blark/util.py
+++ b/blark/util.py
@@ -221,3 +221,11 @@ def find_and_clean_comments(
         return comments_and_pragmas, text
 
     return comments_and_pragmas, "\n".join(lines)
+
+
+def remove_comment_characters(text: str) -> str:
+    """Take only the inner contents of a given comment."""
+    text = text.strip()
+    if text.startswith("/"):
+        return text.lstrip("/ ")
+    return text.strip("()").strip("* ")


### PR DESCRIPTION
## Changes in no particular order
* Reworked how `Meta` instances are transferred over from `lark` to `blark`; add explicit dataclass attributes for them
* Trying out a layer that summarizes transformed code for easier access ("tell me the function blocks, their declared variables/methods/actions, and where to find them")
* Building a sphinx Domain on top of it (looking at sphinx-julia, built-in Python support for inspiration/ideas how to do it)
* Rework some weird code flow from the original `blark parse` CLI
* Some test cleanup
* More test coverage for global var declarations
* Made mypy a lot happier for `blark.transform` (never 100% happy of course)
* Add UNION support (Closes #14 )
* Additional grammar fixes (need to document more of the differences noted when running TwinCAT. As to be expected, blark is more permissive in some cases and too restrictive in others)

## Documentation?
So far, just function blocks + methods:
<img width="720" alt="image" src="https://user-images.githubusercontent.com/5139267/143330215-f8e769bc-46f1-4d9c-bb42-831f62edcb68.png">

Generated by way of pointing to the project in Sphinx `conf.py`:
```
.. bk:functionblock:: FB_TempSensor
```

* Cross-referencing works with function block names, variable/method names.
* Functions, programs, etc. will be easy enough to add when I get time
* No intention of making `sphinx` or `docutils` a required runtime dependency to blark

Things which I don't have a clue how to approach just yet:
* Cross-referencing API docs from source code listings
* And some form of syntax highlighting
* Autodoc (project -> auto-documented pages)

