### PR TITLE
Enhancement: support access specifiers for function block declarations

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,4 @@
+{
+    "python.linting.flake8Enabled": true,
+    "python.linting.enabled": true
+}

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -5,3 +5,4 @@ include LICENSE
 include blark/_version.py
 include blark/*.lark
 include blark/docs/*.css
+recursive-include blark/tests *.TcPOU *.st

--- a/blark/iec.lark
+++ b/blark/iec.lark
@@ -524,7 +524,7 @@ ABSTRACT: "ABSTRACT"i
 extends: "EXTENDS"i DOTTED_IDENTIFIER
 implements: "IMPLEMENTS"i DOTTED_IDENTIFIER ("," DOTTED_IDENTIFIER)*
 
-function_block_type_declaration: FUNCTION_BLOCK [ ABSTRACT ] derived_function_block_name [ extends ] [ implements ] fb_var_declaration* [ function_block_body ] END_FUNCTION_BLOCK ";"*
+function_block_type_declaration: FUNCTION_BLOCK [ method_access ] derived_function_block_name [ extends ] [ implements ] fb_var_declaration* [ function_block_body ] END_FUNCTION_BLOCK ";"*
 
 FUNCTION_BLOCK: "FUNCTION_BLOCK"i
               | "FUNCTIONBLOCK"i

--- a/blark/iec.lark
+++ b/blark/iec.lark
@@ -521,17 +521,17 @@ DOTTED_IDENTIFIER: IDENTIFIER ( "." IDENTIFIER )*
                          | derived_function_block_name
 
 
-FB_ACCESS: "ABSTRACT"i
-         | "PUBLIC"i
-         | "PRIVATE"i
-         | "PROTECTED"i
-         | "INTERNAL"i
-         | "FINAL"i
-fb_access: FB_ACCESS+
+ACCESS_SPECIFIER: "ABSTRACT"i
+                | "PUBLIC"i
+                | "PRIVATE"i
+                | "PROTECTED"i
+                | "INTERNAL"i
+                | "FINAL"i
+access_specifier: ACCESS_SPECIFIER+
 extends: "EXTENDS"i DOTTED_IDENTIFIER
 implements: "IMPLEMENTS"i DOTTED_IDENTIFIER ("," DOTTED_IDENTIFIER)*
 
-function_block_type_declaration: FUNCTION_BLOCK [ fb_access ] derived_function_block_name [ extends ] [ implements ] fb_var_declaration* [ function_block_body ] END_FUNCTION_BLOCK ";"*
+function_block_type_declaration: FUNCTION_BLOCK [ access_specifier ] derived_function_block_name [ extends ] [ implements ] fb_var_declaration* [ function_block_body ] END_FUNCTION_BLOCK ";"*
 
 FUNCTION_BLOCK: "FUNCTION_BLOCK"i
               | "FUNCTIONBLOCK"i
@@ -552,16 +552,6 @@ temp_var_decls: "VAR_TEMP"i var_body "END_VAR"i ";"*
 
 ?function_block_body: statement_list
 
-// TODO: really only a couple of these
-METHOD_ACCESS: "ABSTRACT"i
-             | "PUBLIC"i
-             | "PRIVATE"i
-             | "PROTECTED"i
-             | "INTERNAL"i
-             | "FINAL"i
-
-method_access: METHOD_ACCESS+
-
 var_inst_declaration: "VAR_INST"i [ variable_attributes ] var_body "END_VAR"i ";"*
 
 ?method_var_declaration: fb_var_declaration
@@ -570,22 +560,13 @@ var_inst_declaration: "VAR_INST"i [ variable_attributes ] var_body "END_VAR"i ";
 
 ?method_return_type: _located_var_spec_init
 
-function_block_method_declaration: "METHOD"i [ method_access ] DOTTED_IDENTIFIER [ ":" method_return_type ] ";"* method_var_declaration* [ function_block_body ] "END_METHOD"i ";"*
-
-PROPERTY_ACCESS: "ABSTRACT"i
-               | "PUBLIC"i
-               | "PRIVATE"i
-               | "PROTECTED"i
-               | "INTERNAL"i
-               | "FINAL"i
-
-property_access: PROPERTY_ACCESS+
+function_block_method_declaration: "METHOD"i [ access_specifier ] DOTTED_IDENTIFIER [ ":" method_return_type ] ";"* method_var_declaration* [ function_block_body ] "END_METHOD"i ";"*
 
 ?property_var_declaration: fb_var_declaration
 
 ?property_return_type: _located_var_spec_init
 
-function_block_property_declaration: "PROPERTY"i [ property_access ] DOTTED_IDENTIFIER [ ":" property_return_type ] ";"* property_var_declaration* [ function_block_body ] "END_PROPERTY"i ";"*
+function_block_property_declaration: "PROPERTY"i [ access_specifier ] DOTTED_IDENTIFIER [ ":" property_return_type ] ";"* property_var_declaration* [ function_block_body ] "END_PROPERTY"i ";"*
 
 // B.1.5.3
 ?program_type_name: IDENTIFIER

--- a/blark/iec.lark
+++ b/blark/iec.lark
@@ -520,11 +520,18 @@ DOTTED_IDENTIFIER: IDENTIFIER ( "." IDENTIFIER )*
 ?function_block_type_name: standard_function_block_name
                          | derived_function_block_name
 
-ABSTRACT: "ABSTRACT"i
+
+FB_ACCESS: "ABSTRACT"i
+         | "PUBLIC"i
+         | "PRIVATE"i
+         | "PROTECTED"i
+         | "INTERNAL"i
+         | "FINAL"i
+fb_access: FB_ACCESS+
 extends: "EXTENDS"i DOTTED_IDENTIFIER
 implements: "IMPLEMENTS"i DOTTED_IDENTIFIER ("," DOTTED_IDENTIFIER)*
 
-function_block_type_declaration: FUNCTION_BLOCK [ method_access ] derived_function_block_name [ extends ] [ implements ] fb_var_declaration* [ function_block_body ] END_FUNCTION_BLOCK ";"*
+function_block_type_declaration: FUNCTION_BLOCK [ fb_access ] derived_function_block_name [ extends ] [ implements ] fb_var_declaration* [ function_block_body ] END_FUNCTION_BLOCK ";"*
 
 FUNCTION_BLOCK: "FUNCTION_BLOCK"i
               | "FUNCTIONBLOCK"i

--- a/blark/tests/source/fb_w_public_access.st
+++ b/blark/tests/source/fb_w_public_access.st
@@ -1,7 +1,6 @@
-FUNCTION_BLOCK PUBLIC class_JsonManager
+FUNCTION_BLOCK PUBLIC class_PublicFB
     VAR_OUTPUT
-        (*TRUE if the class is unable to parse a JSON data structure or an
-    navigational or extraction method fails due to invalid JSON architecture.*)
+        (*Some comment.*)
         Error     : BOOL;
     END_VAR
 END_FUNCTION_BLOCK

--- a/blark/tests/source/fb_w_public_access.st
+++ b/blark/tests/source/fb_w_public_access.st
@@ -1,0 +1,7 @@
+FUNCTION_BLOCK PUBLIC class_JsonManager
+    VAR_OUTPUT
+        (*TRUE if the class is unable to parse a JSON data structure or an
+    navigational or extraction method fails due to invalid JSON architecture.*)
+        Error     : BOOL;
+    END_VAR
+END_FUNCTION_BLOCK

--- a/blark/tests/test_parsing.py
+++ b/blark/tests/test_parsing.py
@@ -2,7 +2,7 @@ import pathlib
 
 import pytest
 
-from ..parse import parse, summarize, parse_source_code
+from ..parse import parse, parse_source_code, summarize
 from .conftest import get_grammar
 
 TEST_PATH = pathlib.Path(__file__).parent
@@ -16,9 +16,11 @@ if additional_pous.exists():
 
 sources = list(str(path) for path in TEST_PATH.glob("**/*.st"))
 
+
 @pytest.fixture(params=pous)
 def pou_filename(request):
     return request.param
+
 
 @pytest.fixture(params=sources)
 def source_filename(request):
@@ -37,6 +39,7 @@ def test_parsing_tcpous(pou_filename):
         if isinstance(result, Exception):
             raise result
         print(summarize(result))
+
 
 def test_parsing_source(source_filename):
     """Test plain source 61131 files."""

--- a/blark/tests/test_parsing.py
+++ b/blark/tests/test_parsing.py
@@ -2,7 +2,7 @@ import pathlib
 
 import pytest
 
-from ..parse import parse, summarize
+from ..parse import parse, summarize, parse_source_code
 from .conftest import get_grammar
 
 TEST_PATH = pathlib.Path(__file__).parent
@@ -14,17 +14,38 @@ additional_pous = TEST_PATH / "additional_pous.txt"
 if additional_pous.exists():
     pous += open(additional_pous, "rt").read().splitlines()
 
+sources = list(str(path) for path in TEST_PATH.glob("**/*.st"))
 
 @pytest.fixture(params=pous)
 def pou_filename(request):
     return request.param
 
+@pytest.fixture(params=sources)
+def source_filename(request):
+    return request.param
 
-def test_parsing(pou_filename):
+
+def test_parsing_tcpous(pou_filename):
     try:
         ((_, result),) = list(parse(pou_filename))
     except FileNotFoundError:
         pytest.skip(f"Missing file: {pou_filename}")
+    else:
+        print("transformed:")
+        print(result)
+        print("summary:")
+        if isinstance(result, Exception):
+            raise result
+        print(summarize(result))
+
+def test_parsing_source(source_filename):
+    """Test plain source 61131 files."""
+    try:
+        with open(source_filename, "r", encoding="utf-8") as src:
+            content = src.read()
+        result = parse_source_code(content)
+    except FileNotFoundError:
+        pytest.skip(f"Missing file: {source_filename}")
     else:
         print("transformed:")
         print(result)

--- a/blark/tests/test_transformer.py
+++ b/blark/tests/test_transformer.py
@@ -79,6 +79,7 @@ def test_check_unhandled_rules(grammar):
     aliased = {
         "boolean_literal",
         "fb_decl",
+        "fb_access",
     }
 
     assert set(unhandled_rules) == handled_separately | todo_rules | aliased

--- a/blark/tests/test_transformer.py
+++ b/blark/tests/test_transformer.py
@@ -536,6 +536,36 @@ def test_global_roundtrip(rule_name, value):
         )),
         param("function_block_type_declaration", tf.multiline_code_block(
             """
+            FUNCTION_BLOCK PRIVATE fbName EXTENDS OtherFbName
+            END_FUNCTION_BLOCK
+            """
+        )),
+        param("function_block_type_declaration", tf.multiline_code_block(
+            """
+            FUNCTION_BLOCK PUBLIC fbName EXTENDS OtherFbName
+            END_FUNCTION_BLOCK
+            """
+        )),
+        param("function_block_type_declaration", tf.multiline_code_block(
+            """
+            FUNCTION_BLOCK INTERNAL fbName EXTENDS OtherFbName
+            END_FUNCTION_BLOCK
+            """
+        )),
+        param("function_block_type_declaration", tf.multiline_code_block(
+            """
+            FUNCTION_BLOCK PROTECTED fbName EXTENDS OtherFbName
+            END_FUNCTION_BLOCK
+            """
+        )),
+        param("function_block_type_declaration", tf.multiline_code_block(
+            """
+            FUNCTION_BLOCK FINAL fbName EXTENDS OtherFbName
+            END_FUNCTION_BLOCK
+            """
+        )),
+        param("function_block_type_declaration", tf.multiline_code_block(
+            """
             FUNCTION_BLOCK fbName
             VAR_INPUT
                 bExecute : BOOL;

--- a/blark/tests/test_transformer.py
+++ b/blark/tests/test_transformer.py
@@ -79,7 +79,6 @@ def test_check_unhandled_rules(grammar):
     aliased = {
         "boolean_literal",
         "fb_decl",
-        "fb_access",
     }
 
     assert set(unhandled_rules) == handled_separately | todo_rules | aliased

--- a/blark/transform.py
+++ b/blark/transform.py
@@ -207,10 +207,9 @@ class VariableAttributes(_FlagHelper, enum.Flag):
 
 
 @_rule_handler(
-    "method_access",
-    "property_access",
+    "access_specifier",
 )
-class MethodAccess(_FlagHelper, enum.Flag):
+class AccessSpecifier(_FlagHelper, enum.Flag):
     public = 0b0000_0001
     private = 0b0000_0010
     abstract = 0b0000_0100
@@ -1913,7 +1912,7 @@ class Action:
 @dataclass
 @_rule_handler("function_block_method_declaration", comments=True)
 class Method:
-    access: Optional[MethodAccess]
+    access: Optional[AccessSpecifier]
     name: lark.Token
     return_type: Optional[LocatedVariableSpecInit]
     declarations: List[VariableDeclarationBlock]
@@ -1922,7 +1921,7 @@ class Method:
 
     @staticmethod
     def from_lark(
-        access: Optional[MethodAccess],
+        access: Optional[AccessSpecifier],
         name: lark.Token,
         return_type: Optional[LocatedVariableSpecInit],
         *args
@@ -1954,7 +1953,7 @@ class Method:
 @dataclass
 @_rule_handler("function_block_property_declaration", comments=True)
 class Property:
-    access: Optional[MethodAccess]
+    access: Optional[AccessSpecifier]
     name: lark.Token
     return_type: Optional[LocatedVariableSpecInit]
     declarations: List[VariableDeclarationBlock]
@@ -1963,7 +1962,7 @@ class Property:
 
     @staticmethod
     def from_lark(
-        access: Optional[MethodAccess],
+        access: Optional[AccessSpecifier],
         name: lark.Token,
         return_type: Optional[LocatedVariableSpecInit],
         *args
@@ -3035,8 +3034,8 @@ if apischema is not None:
     # Optional apischema deserializers
 
     @apischema.deserializer
-    def _method_access_deserializer(access: int) -> MethodAccess:
-        return MethodAccess(access)
+    def _method_access_deserializer(access: int) -> AccessSpecifier:
+        return AccessSpecifier(access)
 
     @apischema.deserializer
     def _var_attrs_deserializer(attrs: int) -> VariableAttributes:

--- a/blark/transform.py
+++ b/blark/transform.py
@@ -1787,7 +1787,7 @@ class Implements:
 @_rule_handler("function_block_type_declaration", comments=True)
 class FunctionBlock:
     name: lark.Token
-    abstract: bool
+    access: Optional[AccessSpecifier]
     extends: Optional[Extends]
     implements: Optional[Implements]
     declarations: List[VariableDeclarationBlock]
@@ -1797,7 +1797,7 @@ class FunctionBlock:
     @staticmethod
     def from_lark(
         fb_token: lark.Token,
-        abstract: Optional[lark.Token],
+        access: Optional[AccessSpecifier],
         derived_name: lark.Token,
         extends: Optional[Extends],
         implements: Optional[Implements],
@@ -1806,7 +1806,7 @@ class FunctionBlock:
         *declarations, body, _ = args
         return FunctionBlock(
             name=derived_name,
-            abstract=abstract is not None,
+            access=access is not None,
             extends=extends,
             implements=implements,
             declarations=list(declarations),

--- a/blark/transform.py
+++ b/blark/transform.py
@@ -1806,7 +1806,7 @@ class FunctionBlock:
         *declarations, body, _ = args
         return FunctionBlock(
             name=derived_name,
-            access=access is not None,
+            access=access,
             extends=extends,
             implements=implements,
             declarations=list(declarations),
@@ -1814,8 +1814,8 @@ class FunctionBlock:
         )
 
     def __str__(self) -> str:
-        abstract = "ABSTRACT " if self.abstract else ""
-        header = f"FUNCTION_BLOCK {abstract}{self.name}"
+        access_and_name = join_if(self.access, " ", self.name)
+        header = f"FUNCTION_BLOCK {access_and_name}"
         header = join_if(header, " ", self.implements)
         header = join_if(header, " ", self.extends)
         return "\n".join(


### PR DESCRIPTION
# Changes:
* Enhances grammar to qualify function blocks with more broad access specifiers, including:
    * ABSTRACT (pre-existing)
    * PUBLIC
    * PRIVATE
    * PROTECTED
    * INTERNAL
    * FINAL
* Adds tests to validate 61131 source directly, without the use of `*.TcPOU` files.


### Closing Thoughts:
Please let me know if there are any questions or concerns with the changes! I have a few other enhancements I would like to contribute, and I want to make sure that my contributions are effective, and in-line with the direction you want to maintain.

Thank you so much!