### PR TITLE
Add Support of Indirection in Unions

### DIFF
--- a/blark/iec.lark
+++ b/blark/iec.lark
@@ -315,7 +315,7 @@ initialized_structure: structure_type_name ":=" structure_initialization
 
 structure_element_declaration: structure_element_name [ incomplete_location ] ":" ( initialized_structure | array_spec_init | simple_spec_init | subrange_spec_init | enumerated_spec_init )
 
-union_element_declaration: structure_element_name ":" ( array_specification | simple_specification | subrange_specification | enumerated_specification )
+union_element_declaration: structure_element_name ":" ( array_specification | simple_specification | indirect_simple_specification | subrange_specification | enumerated_specification )
 
 union_type_declaration: structure_type_name ":" "UNION"i ( union_element_declaration ";"+ )* "END_UNION"i ";"*
 

--- a/blark/tests/test_transformer.py
+++ b/blark/tests/test_transformer.py
@@ -1093,6 +1093,16 @@ def test_incomplete_located_var_decls(rule_name, value):
             END_TYPE
             """
         )),
+        param("data_type_declaration", tf.multiline_code_block(
+            """
+            TYPE TypeName :
+                UNION
+                    pt_value : POINTER TO INT;
+                    as_bytes : ARRAY [0..2] OF BYTE;
+                END_UNION
+            END_TYPE
+            """
+        )),
     ],
 )
 def test_data_type_declaration(rule_name, value):

--- a/blark/tests/test_transformer.py
+++ b/blark/tests/test_transformer.py
@@ -1098,7 +1098,7 @@ def test_incomplete_located_var_decls(rule_name, value):
             TYPE TypeName :
                 UNION
                     pt_value : POINTER TO INT;
-                    as_bytes : ARRAY [0..2] OF BYTE;
+                    pt_SomethingElse : POINTER TO class_SomethingCool;
                 END_UNION
             END_TYPE
             """

--- a/blark/transform.py
+++ b/blark/transform.py
@@ -1200,6 +1200,7 @@ UnionElementSpecification = Union[
     SimpleSpecification,
     SubrangeSpecification,
     EnumeratedSpecification,
+    IndirectSimpleSpecification,
 ]
 
 


### PR DESCRIPTION
# Changes:
* Add support for POINTER/REFERENCE TO in Union data structures. Example:

```
TYPE TypeName :
    UNION
        pt_value : POINTER TO INT;
        pt_SomethingElse : POINTER TO class_SomethingCool;
    END_UNION
END_TYPE
```

### Closing Thoughts:
I couldn't find a good sample set of documentation for this, but I've used unions for pointer manipulation in a few cases. Most commonly when dealing with dynamic memory allocations. Please let me know if you have any questions about this!