### PR TITLE
Enhance: Function and Data Type Access Specifier, and Structures using FB_Init args

### DIFF
--- a/blark/iec.lark
+++ b/blark/iec.lark
@@ -495,7 +495,7 @@ string_type_specification: STRING [ STRING_SPEC_LENGTH ]
 
 indirect_simple_specification: [ indirection_type ] simple_specification
 
-function_declaration: "FUNCTION"i derived_function_name [ ":" indirect_simple_specification ] ";"* [ function_var_block+ ] [ function_body ] "END_FUNCTION"i ";"*
+function_declaration: "FUNCTION"i [ access_specifier ] derived_function_name [ ":" indirect_simple_specification ] ";"* [ function_var_block+ ] [ function_body ] "END_FUNCTION"i ";"*
 
 ?function_var_block: input_declarations
                    | output_declarations

--- a/blark/iec.lark
+++ b/blark/iec.lark
@@ -313,7 +313,7 @@ initialized_structure_type_declaration: structure_type_name [ extends ] ":" init
 
 initialized_structure: structure_type_name ":=" structure_initialization
 
-structure_element_declaration: structure_element_name [ incomplete_location ] ":" ( initialized_structure | array_spec_init | simple_spec_init | subrange_spec_init | enumerated_spec_init )
+structure_element_declaration: structure_element_name [ incomplete_location ] ":" ( initialized_structure | array_spec_init | simple_spec_init | subrange_spec_init | enumerated_spec_init | function_call )
 
 union_element_declaration: structure_element_name ":" ( array_specification | simple_specification | indirect_simple_specification | subrange_specification | enumerated_specification )
 

--- a/blark/iec.lark
+++ b/blark/iec.lark
@@ -239,7 +239,7 @@ REFERENCE_TO: /REFERENCE\s*TO/i
                          | subrange_type_name
                          | enumerated_type_name
 
-data_type_declaration: "TYPE"i [ _type_declaration ] ";"* "END_TYPE"i ";"*
+data_type_declaration: "TYPE"i [ access_specifier ] [ _type_declaration ] ";"* "END_TYPE"i ";"*
 
 _type_declaration: array_type_declaration
                  | structure_type_declaration

--- a/blark/iec.lark
+++ b/blark/iec.lark
@@ -404,7 +404,7 @@ structured_var_init_decl: var1_list ":" initialized_structure
 
 // Function blocks
 fb_decl: fb_decl_name_list ":" function_block_type_name [ ":=" structure_initialization ] -> fb_name_decl
-       | fb_decl_name_list ":" fb_invocation                                              -> fb_invocation_decl
+       | fb_decl_name_list ":" function_call                                              -> fb_invocation_decl
 
 fb_decl_name_list: fb_name ( "," fb_name )*
 
@@ -438,7 +438,7 @@ global_var_declarations: "VAR_GLOBAL"i [ variable_attributes ] global_var_body_i
 ?global_var_body_item: var_init_decl
                      | global_var_decl
 
-global_var_decl: global_var_spec ":" ( _located_var_spec_init | fb_invocation ) ";"+
+global_var_decl: global_var_spec ":" ( _located_var_spec_init | function_call ) ";"+
 // Note - function_block_type_name is also valid here, but it is picked up by
 //   an equivalent rule
 //   function_block_type_name
@@ -668,7 +668,6 @@ UNARY_OPERATOR: LOGICAL_NOT
 
 function_call: symbolic_variable "(" [ param_assignment ( "," param_assignment )* ","? ] ")"
 
-// see also: fb_invocation
 ?primary_expression: "(" expression ")"      -> parenthesized_expression
                    | function_call
                    | _variable
@@ -685,7 +684,7 @@ _statement: ";"
           | reset_statement
           | reference_assignment_statement
           | return_statement
-          | fb_invocation_statement
+          | function_call_statement
           | if_statement
           | case_statement
           | for_statement
@@ -712,9 +711,7 @@ method_statement: symbolic_variable "(" ")" ";"+
 return_statement.1: "RETURN"i ";"*
 // return_statement: priority > 0 so that it doesn't clash with no_op_statement
 
-fb_invocation_statement: fb_invocation ";"+
-
-fb_invocation: symbolic_variable "(" [ param_assignment ( "," param_assignment )* ","? ] ")"
+function_call_statement: function_call ";"+
 
 param_assignment: [ LOGICAL_NOT ] variable_name "=>" [ expression ] -> output_parameter_assignment
                 | variable_name ":=" [ expression ]

--- a/blark/tests/test_transformer.py
+++ b/blark/tests/test_transformer.py
@@ -1158,7 +1158,7 @@ def test_data_type_declaration(rule_name, value):
         ),
         param(
             "fValue : FB_Test(A := 1, B := 2, C => 3);",
-            tf.FunctionBlockInvocation,
+            tf.FunctionCall,
             "FB_Test",
             "FB_Test",
         ),

--- a/blark/tests/test_transformer.py
+++ b/blark/tests/test_transformer.py
@@ -1105,6 +1105,16 @@ def test_incomplete_located_var_decls(rule_name, value):
         )),
         param("data_type_declaration", tf.multiline_code_block(
             """
+            TYPE TypeName :
+                STRUCT
+                    object : class_InitializeWithFBInit(input := one);
+                    interval : INT;
+                END_STRUCT
+            END_TYPE
+            """
+        )),
+        param("data_type_declaration", tf.multiline_code_block(
+            """
             TYPE INTERNAL EnumTypeName : (ENUM_VAL_1 := 0, ENUM_VAL_2);
             END_TYPE
             """

--- a/blark/tests/test_transformer.py
+++ b/blark/tests/test_transformer.py
@@ -888,6 +888,17 @@ def test_statement_roundtrip(rule_name, value):
         ),
         param("function_declaration", tf.multiline_code_block(
             """
+            FUNCTION INTERNAL FuncName : INT
+                VAR_INPUT
+                    iValue : INT := 0;
+                END_VAR
+                FuncName := iValue;
+            END_FUNCTION
+            """),
+            id="int_with_input",
+        ),
+        param("function_declaration", tf.multiline_code_block(
+            """
             FUNCTION FuncName : POINTER TO INT
                 VAR
                     iValue : INT := 0;

--- a/blark/tests/test_transformer.py
+++ b/blark/tests/test_transformer.py
@@ -1103,6 +1103,12 @@ def test_incomplete_located_var_decls(rule_name, value):
             END_TYPE
             """
         )),
+        param("data_type_declaration", tf.multiline_code_block(
+            """
+            TYPE INTERNAL EnumTypeName : (ENUM_VAL_1 := 0, ENUM_VAL_2);
+            END_TYPE
+            """
+        )),
     ],
 )
 def test_data_type_declaration(rule_name, value):

--- a/blark/transform.py
+++ b/blark/transform.py
@@ -1836,6 +1836,7 @@ class FunctionBlock:
 @dataclass
 @_rule_handler("function_declaration", comments=True)
 class Function:
+    access: Optional[AccessSpecifier]
     name: lark.Token
     return_type: Optional[Union[SimpleSpecification, IndirectSimpleSpecification]]
     declarations: List[VariableDeclarationBlock]
@@ -1844,6 +1845,7 @@ class Function:
 
     @staticmethod
     def from_lark(
+        access: Optional[AccessSpecifier],
         name: lark.Token,
         return_type: Optional[Union[SimpleSpecification, IndirectSimpleSpecification]],
         *remainder
@@ -1851,6 +1853,7 @@ class Function:
         *declarations, body = remainder
         return Function(
             name=name,
+            access=access,
             return_type=return_type,
             declarations=typing.cast(
                 List[VariableDeclarationBlock], list(declarations)
@@ -1859,7 +1862,8 @@ class Function:
         )
 
     def __str__(self) -> str:
-        function = f"FUNCTION {self.name}"
+        access_and_name = join_if(self.access, " ", self.name)
+        function = f"FUNCTION {access_and_name}"
         return_type = f": {self.return_type}" if self.return_type else None
         return "\n".join(
             line for line in

--- a/blark/transform.py
+++ b/blark/transform.py
@@ -2808,13 +2808,15 @@ TypeDeclarationItem = Union[
 @_rule_handler("data_type_declaration", comments=True)
 class DataTypeDeclaration:
     declaration: Optional[TypeDeclarationItem]
+    access: Optional[AccessSpecifier]
     meta: Optional[Meta] = meta_field()
 
     @staticmethod
     def from_lark(
+        access: Optional[AccessSpecifier],
         declaration: Optional[TypeDeclarationItem] = None,
     ) -> DataTypeDeclaration:
-        return DataTypeDeclaration(declaration)
+        return DataTypeDeclaration(access=access, declaration=declaration)
 
     def __str__(self) -> str:
         if not self.declaration:
@@ -2826,6 +2828,8 @@ class DataTypeDeclaration:
         ):
             # note: END_STRUCT; END_UNION; result in "END_TYPE expected not ;"
             decl = decl + ";"
+
+        decl = join_if(self.access, " ", decl)
 
         return "\n".join(
             (

--- a/blark/transform.py
+++ b/blark/transform.py
@@ -1182,6 +1182,7 @@ class StructureElementDeclaration:
         SubrangeTypeInitialization,
         EnumeratedTypeInitialization,
         InitializedStructure,
+        FunctionCall,
     ]
     meta: Optional[Meta] = meta_field()
 


### PR DESCRIPTION
# Changes:
* Add support for Access Specifier for Functions
  ![image](https://user-images.githubusercontent.com/33275230/164301119-1e4498b8-572e-4759-9129-a2e6ec8b2abb.png)
* Add support for Access Specifier in Struct/Union/Enum Types
  ![image](https://user-images.githubusercontent.com/33275230/164300954-502d6ec9-4a59-493e-8906-dff122c91542.png)
* Add support for Use of Instantiated function-blocks with FB_Init arguments
  ![image](https://user-images.githubusercontent.com/33275230/164301510-659101cf-657d-4eed-94da-38b10867547a.png)


### Closing Thoughts:
I'm not absolutely sure that I'm following the correct practice in regards to the addition of `FunctionCall` in the `StructureElementDeclaration` [see here](https://github.com/klauer/blark/compare/master...engineerjoe440:enhancement/func-access_struct-fb-init-args_data-type-access?expand=1#diff-c26321b40313af0a101f2abfe0076eb50f721b233e65e3f5db676c2cbd4054f3R1185). That said, I'm happy to make any adjustments as you see fit! I'm sorry that I couldn't find better references for the use of access specifiers for functions and type declarations. It seems that feature is not very widely documented.