### PR TITLE
Enhancement/support recursive pointer to

### DIFF
--- a/blark/iec.lark
+++ b/blark/iec.lark
@@ -278,9 +278,9 @@ _type_declaration: array_type_declaration
 
 simple_type_declaration: simple_type_name [ extends ] ":" simple_spec_init
 
-indirection_type: POINTER_TO
+indirection_type: POINTER_TO+
                 | REFERENCE_TO
-pointer_type: POINTER_TO
+pointer_type: POINTER_TO+
 
 simple_spec_init: [ indirection_type ] simple_specification [ ":=" expression ]
 

--- a/blark/iec.lark
+++ b/blark/iec.lark
@@ -278,8 +278,9 @@ _type_declaration: array_type_declaration
 
 simple_type_declaration: simple_type_name [ extends ] ":" simple_spec_init
 
-indirection_type: POINTER_TO+
-                | REFERENCE_TO
+indirection_type: REFERENCE_TO
+                | POINTER_TO+
+                | REFERENCE_TO POINTER_TO+
 pointer_type: POINTER_TO+
 
 simple_spec_init: [ indirection_type ] simple_specification [ ":=" expression ]

--- a/blark/tests/source/pointer_to_pointer_to.st
+++ b/blark/tests/source/pointer_to_pointer_to.st
@@ -1,0 +1,6 @@
+FUNCTION_BLOCK fb_test
+    VAR
+        _pt_Strings : POINTER TO POINTER TO someObject;
+        _pt_Current : POINTER TO POINTER TO someObject;
+    END_VAR
+END_FUNCTION_BLOCK

--- a/blark/tests/test_transformer.py
+++ b/blark/tests/test_transformer.py
@@ -247,6 +247,7 @@ def test_bool_literal_roundtrip(name, value, expected):
         param("simple_type_declaration", "TypeName : REFERENCE TO INT"),
         param("simple_type_declaration", "TypeName : POINTER TO INT"),
         param("simple_type_declaration", "TypeName : POINTER TO POINTER TO INT"),
+        param("simple_type_declaration", "TypeName : REFERENCE TO POINTER TO INT"),
         param("simple_type_declaration", "TypeName EXTENDS a.b : POINTER TO INT"),
         param("subrange_type_declaration", "TypeName : INT (1..2)"),
         param("subrange_type_declaration", "TypeName : INT (*) := 1"),

--- a/blark/tests/test_transformer.py
+++ b/blark/tests/test_transformer.py
@@ -246,6 +246,7 @@ def test_bool_literal_roundtrip(name, value, expected):
         param("simple_type_declaration", "TypeName : INT := 5 + 1 * (2)"),
         param("simple_type_declaration", "TypeName : REFERENCE TO INT"),
         param("simple_type_declaration", "TypeName : POINTER TO INT"),
+        param("simple_type_declaration", "TypeName : POINTER TO POINTER TO INT"),
         param("simple_type_declaration", "TypeName EXTENDS a.b : POINTER TO INT"),
         param("subrange_type_declaration", "TypeName : INT (1..2)"),
         param("subrange_type_declaration", "TypeName : INT (*) := 1"),

--- a/blark/transform.py
+++ b/blark/transform.py
@@ -632,7 +632,7 @@ class IndirectionType:
         upper_tokens = list(map(lambda s: str(s).upper(), tokens))
         if len(tokens) > 0:
             pointer_depth = upper_tokens.count("POINTER TO")
-            reference = "REFERENCE TO" in tokens
+            reference = "REFERENCE TO" in upper_tokens
         return IndirectionType(
             pointer_depth=pointer_depth,
             reference=reference

--- a/blark/transform.py
+++ b/blark/transform.py
@@ -626,12 +626,12 @@ class IndirectionType(Literal):
     meta: Optional[Meta] = meta_field()
 
     @staticmethod
-    def from_lark(token: Optional[lark.Token]) -> IndirectionType:
+    def from_lark(*tokens: Tuple[lark.Token]) -> IndirectionType:
         pointer_depth = 0
         reference = False
-        if token is not None:
-            pointer_depth = token.count("POINTER TO")
-            reference = token.startswith("REFERENCE TO")
+        if len(tokens) > 0:
+            pointer_depth = tokens.count("POINTER TO")
+            reference = "REFERENCE TO" in tokens
         return IndirectionType(
             pointer_depth=pointer_depth,
             reference=reference

--- a/blark/transform.py
+++ b/blark/transform.py
@@ -619,18 +619,19 @@ class Variable(Expression):
     "indirection_type",
     "pointer_type",
 )
-class IndirectionType(Literal):
+class IndirectionType:
     """Indirect access through a pointer or reference."""
     pointer_depth: int
     reference: bool
     meta: Optional[Meta] = meta_field()
 
     @staticmethod
-    def from_lark(*tokens: Tuple[lark.Token]) -> IndirectionType:
+    def from_lark(*tokens: lark.Token) -> IndirectionType:
         pointer_depth = 0
         reference = False
+        upper_tokens = list(map(lambda s: str(s).upper(), tokens))
         if len(tokens) > 0:
-            pointer_depth = tokens.count("POINTER TO")
+            pointer_depth = upper_tokens.count("POINTER TO")
             reference = "REFERENCE TO" in tokens
         return IndirectionType(
             pointer_depth=pointer_depth,
@@ -639,15 +640,10 @@ class IndirectionType(Literal):
 
     @property
     def value(self) -> str:
-        pointer_str = None
-        if self.pointer_depth > 0:
-            pointer_str = " ".join(["POINTER TO"] * self.pointer_depth)
-        indirection_str = join_if(
-            "REFERENCE TO" if self.reference else None,
-            " ",
-            pointer_str,
+        return " ".join(
+            ["REFERENCE TO"] * self.reference +
+            ["POINTER TO"] * self.pointer_depth
         )
-        return indirection_str
 
     def __str__(self):
         return self.value


### PR DESCRIPTION
# Changes:
* Add support for recursive `POINTER TO` while only allowing `REFERENCE TO` at the "outermost level" (e.g., `REFERENCE TO POINTER TO INT`)

## Linked Issues:
* #32 

## Reason for Draft State:
The content here is failing `pytest` due to a failure (on my part) to implement `from_lark` to allow multiple token arguments. I'm sure it's something little that I'm overlooking, but I'm completely missing it.

#### Closing Thoughts:
I'm sure there are some cleaner ways of implementing what I've added, and I could very well be misinterpreting some of the `dataclass` structure, so please let me know if I've missed anything. Thank you!