### PR TITLE
Bugfix/Enhancement: Add Support of `bit_string_literal` in CASE Statements

### DIFF
--- a/blark/iec.lark
+++ b/blark/iec.lark
@@ -760,6 +760,7 @@ case_list: case_list_element ( "," case_list_element )*
 ?case_list_element: subrange
                   | integer_literal
                   | bit_string_literal
+                  | boolean_literal
                   | enumerated_value
                   | symbolic_variable
 

--- a/blark/iec.lark
+++ b/blark/iec.lark
@@ -759,6 +759,7 @@ case_list: case_list_element ( "," case_list_element )*
 
 ?case_list_element: subrange
                   | integer_literal
+                  | bit_string_literal
                   | enumerated_value
                   | symbolic_variable
 

--- a/blark/tests/source/commas_in_case.st
+++ b/blark/tests/source/commas_in_case.st
@@ -1,0 +1,22 @@
+(*<textarea rows="15" cols="81">
+********************************************************************************
+* Comments
+********************************************************************************
+</textarea>*)
+FUNCTION fun_CommainCase : BOOL
+VAR_INPUT
+    (* Byte to be evaluated as a printable character. *)
+    character : BYTE;
+END_VAR
+
+CASE character OF
+    (*
+    Any character that falls in the ascii range (in base-10)
+    0-8, 11, 12, 14-27 or >=127 is an invalid character.
+    *)
+    BYTE#9..BYTE#10, BYTE#13, BYTE#28..BYTE#126:
+        fun_CommainCase := TRUE;
+ELSE
+    fun_CommainCase := FALSE;
+END_CASE
+END_FUNCTION

--- a/blark/tests/test_transformer.py
+++ b/blark/tests/test_transformer.py
@@ -845,6 +845,16 @@ def test_fb_roundtrip(rule_name, value):
             END_CASE
             """
         )),
+        param("case_statement", tf.multiline_code_block(
+            """
+            CASE expr OF
+            TRUE:
+                abc();
+            FALSE:
+                def();
+            END_CASE
+            """
+        )),
         param("while_statement", tf.multiline_code_block(
             """
             WHILE expr

--- a/blark/tests/test_transformer.py
+++ b/blark/tests/test_transformer.py
@@ -836,6 +836,15 @@ def test_fb_roundtrip(rule_name, value):
             END_CASE
             """
         )),
+        param("case_statement", tf.multiline_code_block(
+            """
+            CASE expr OF
+            BYTE#9..BYTE#10, BYTE#13, BYTE#28:
+                OneToTen := OneToTen + 1;
+            EnumValue:
+            END_CASE
+            """
+        )),
         param("while_statement", tf.multiline_code_block(
             """
             WHILE expr

--- a/blark/transform.py
+++ b/blark/transform.py
@@ -2658,7 +2658,14 @@ class IfStatement(Statement):
         )
 
 
-CaseMatch = Union[Subrange, Integer, EnumeratedValue, SymbolicVariable]
+CaseMatch = Union[
+    Subrange,
+    Integer,
+    EnumeratedValue,
+    SymbolicVariable,
+    BitString,
+    Boolean,
+]
 
 
 @dataclass


### PR DESCRIPTION
# Changes:
* Add `bit_string_literal` to list of `case_list_elements`
* Add test of CASE with `BYTE#...`
* Add source file to verify CASE in context.

# Issues Addressed:
* #34 

#### Closing Thoughts:
This still may be better enhanced by including `boolean_literal`, but I'm not quite sure of that.