### PR TITLE
Enhancements and Fixes Found While Testing Code Base

### DIFF
--- a/blark/iec.lark
+++ b/blark/iec.lark
@@ -529,6 +529,7 @@ function_declaration: "FUNCTION"i [ access_specifier ] derived_function_name [ "
                    | output_declarations
                    | input_output_declarations
                    | static_var_declarations
+                   | external_var_declarations
                    | function_var_declarations
 
 function_var_declarations: "VAR"i [ variable_attributes ] var_body "END_VAR"i ";"*

--- a/blark/iec.lark
+++ b/blark/iec.lark
@@ -166,7 +166,8 @@ ltime_of_day: ("LTIME_OF_DAY"i | "LTOD"i) "#" _daytime
 
 ?day_hour: INTEGER
 ?day_minute: INTEGER
-?day_second: FIXED_POINT
+?day_second: INTEGER
+           | FIXED_POINT
 
 date: ( "DATE"i | "D"i | "d"i ) "#" _date_literal
 ldate: "LDATE"i "#" _date_literal

--- a/blark/iec.lark
+++ b/blark/iec.lark
@@ -257,6 +257,8 @@ GENERIC_TYPE_NAME: "ANY"
 ?structure_element_name: IDENTIFIER
 ?string_type_name: IDENTIFIER
 
+?structure_type_name_declaration: IDENTIFIER
+
 POINTER_TO: /POINTER\s*TO/i
 REFERENCE_TO: /REFERENCE\s*TO/i
 
@@ -339,9 +341,9 @@ _array_initial_element: constant
                       | structure_initialization
                       | enumerated_value
 
-structure_type_declaration: structure_type_name [ extends ] ":" [ indirection_type ] "STRUCT"i ( structure_element_declaration ";"+ )* "END_STRUCT"i
+structure_type_declaration: structure_type_name_declaration [ extends ] ":" [ indirection_type ] "STRUCT"i ( structure_element_declaration ";"+ )* "END_STRUCT"i
 
-initialized_structure_type_declaration: structure_type_name [ extends ] ":" initialized_structure
+initialized_structure_type_declaration: structure_type_name_declaration [ extends ] ":" initialized_structure
 
 initialized_structure: structure_type_name ":=" structure_initialization
 
@@ -349,7 +351,7 @@ structure_element_declaration: structure_element_name [ incomplete_location ] ":
 
 union_element_declaration: structure_element_name ":" ( array_specification | simple_specification | indirect_simple_specification | subrange_specification | enumerated_specification )
 
-union_type_declaration: structure_type_name ":" "UNION"i ( union_element_declaration ";"+ )* "END_UNION"i ";"*
+union_type_declaration: structure_type_name_declaration ":" "UNION"i ( union_element_declaration ";"+ )* "END_UNION"i ";"*
 
 structure_initialization: "(" structure_element_initialization ( "," structure_element_initialization )* ")"
 

--- a/blark/iec.lark
+++ b/blark/iec.lark
@@ -160,7 +160,7 @@ nanoseconds: FIXED_POINT "ns"i
            | INTEGER "ns"i
 
 // B.1.2.3.2
-_daytime: day_hour ":" day_minute ":" day_second
+_daytime: day_hour ":" day_minute [ ":" day_second ]
 
 time_of_day: ("TIME_OF_DAY"i | "TOD"i) "#" _daytime
 ltime_of_day: ("LTIME_OF_DAY"i | "LTOD"i) "#" _daytime

--- a/blark/iec.lark
+++ b/blark/iec.lark
@@ -324,6 +324,7 @@ array_spec_init: [ indirection_type ] array_specification [ ":=" array_initializ
 array_specification: "ARRAY"i "[" subrange ( "," subrange )* "]" "OF"i _array_spec_type_name
 
 _array_spec_type_name: STRING_TYPE
+                     | function_call
                      | non_generic_type_name
 
 array_initialization: "[" array_initial_element ( "," array_initial_element )* "]"

--- a/blark/iec.lark
+++ b/blark/iec.lark
@@ -253,6 +253,7 @@ GENERIC_TYPE_NAME: "ANY"
 ?enumerated_type_name: IDENTIFIER
 ?array_type_name: IDENTIFIER
 ?structure_type_name: IDENTIFIER
+                    | DOTTED_IDENTIFIER
 ?structure_element_name: IDENTIFIER
 ?string_type_name: IDENTIFIER
 

--- a/blark/iec.lark
+++ b/blark/iec.lark
@@ -464,7 +464,12 @@ PERSISTENT: "PERSISTENT"i
 
 action: "ACTION"i action_name ":" [ function_block_body ] "END_ACTION"i ";"*
 
-global_var_declarations: "VAR_GLOBAL"i [ variable_attributes ] global_var_body_item* "END_VAR"i ";"*
+global_var_declarations: "VAR_GLOBAL"i [ global_variable_attributes ] global_var_body_item* "END_VAR"i ";"*
+
+GLOBAL_VAR_ATTRIB: VAR_ATTRIB
+                 | "INTERNAL"
+
+global_variable_attributes: GLOBAL_VAR_ATTRIB+
 
 ?global_var_body_item: var_init_decl
                      | global_var_decl

--- a/blark/iec.lark
+++ b/blark/iec.lark
@@ -278,9 +278,9 @@ _type_declaration: array_type_declaration
 
 simple_type_declaration: simple_type_name [ extends ] ":" simple_spec_init
 
-indirection_type: POINTER_TO
+indirection_type: POINTER_TO+
                 | REFERENCE_TO
-pointer_type: POINTER_TO
+pointer_type: POINTER_TO+
 
 simple_spec_init: [ indirection_type ] simple_specification [ ":=" expression ]
 

--- a/blark/iec.lark
+++ b/blark/iec.lark
@@ -29,6 +29,7 @@ _library_element_declaration: data_type_declaration
                             | program_declaration
                             | global_var_declarations
                             | action
+                            | ";"
 
 // B.1.1
 IDENTIFIER: /[A-Za-z_][A-Za-z0-9_]*/i

--- a/blark/iec.lark
+++ b/blark/iec.lark
@@ -278,8 +278,9 @@ _type_declaration: array_type_declaration
 
 simple_type_declaration: simple_type_name [ extends ] ":" simple_spec_init
 
-indirection_type: POINTER_TO+
-                | REFERENCE_TO
+indirection_type: REFERENCE_TO
+                | POINTER_TO+
+                | REFERENCE_TO POINTER_TO+
 pointer_type: POINTER_TO+
 
 simple_spec_init: [ indirection_type ] simple_specification [ ":=" expression ]

--- a/blark/tests/source/array_of_objects.st
+++ b/blark/tests/source/array_of_objects.st
@@ -1,0 +1,8 @@
+{attribute 'hide'}
+METHOD prv_Detection : BOOL
+VAR_IN_OUT
+        currentChannel : ARRAY[APhase..CPhase] OF class_baseVector(SIZEOF(vector_t),0);
+END_VAR
+
+// do some stuff
+END_METHOD

--- a/blark/tests/source/pointer_to_pointer_to.st
+++ b/blark/tests/source/pointer_to_pointer_to.st
@@ -1,0 +1,6 @@
+FUNCTION_BLOCK fb_test
+    VAR
+        _pt_Strings : POINTER TO POINTER TO someObject;
+        _pt_Current : POINTER TO POINTER TO someObject;
+    END_VAR
+END_FUNCTION_BLOCK

--- a/blark/tests/source/stray_comment.st
+++ b/blark/tests/source/stray_comment.st
@@ -1,0 +1,16 @@
+(* Call this method to truncate an LREAL value *);
+{attribute 'hide'}
+METHOD prv_Floor : LREAL
+VAR_INPUT
+        Input : LREAL;
+END_VAR
+VAR
+        Round : LINT;
+END_VAR
+Round := LREAL_TO_LINT(Input);
+IF LINT_TO_LREAL(Round) <= Input THEN
+        prv_Floor := LINT_TO_LREAL(Round);
+ELSE
+        prv_Floor := LINT_TO_LREAL(Round - 1);
+END_IF
+END_METHOD

--- a/blark/tests/test_transformer.py
+++ b/blark/tests/test_transformer.py
@@ -807,6 +807,20 @@ def test_fb_roundtrip(rule_name, value):
         )),
         param("if_statement", tf.multiline_code_block(
             """
+            IF callable() THEN
+                y();
+            END_IF
+            """
+        )),
+        param("if_statement", tf.multiline_code_block(
+            """
+            IF a() AND b(in := 5) <> 0 AND c(in1 := expr, in2 := 'test') THEN
+                y();
+            END_IF
+            """
+        )),
+        param("if_statement", tf.multiline_code_block(
+            """
             IF 1 AND_THEN 1 THEN
                 y();
             END_IF

--- a/blark/tests/test_transformer.py
+++ b/blark/tests/test_transformer.py
@@ -175,6 +175,7 @@ def test_literal(name, value, expected):
         param("time_of_day", "TIME_OF_DAY#1:1:1.2"),
         param("date", "DATE#1970-1-1"),
         param("date_and_time", "DT#1970-1-1-1:2:30.3"),
+        param("date_and_time", "DT#1970-1-1-0:0:0"),
         param("ldate", "LDATE#1970-1-1"),
         param("ldate_and_time", "LDT#1970-1-1-1:2:30.300123456"),
         param("single_byte_string_spec", "STRING[1]"),

--- a/blark/tests/test_transformer.py
+++ b/blark/tests/test_transformer.py
@@ -176,6 +176,7 @@ def test_literal(name, value, expected):
         param("date", "DATE#1970-1-1"),
         param("date_and_time", "DT#1970-1-1-1:2:30.3"),
         param("date_and_time", "DT#1970-1-1-0:0:0"),
+        param("date_and_time", "DT#1970-1-1-0:0"),
         param("ldate", "LDATE#1970-1-1"),
         param("ldate_and_time", "LDT#1970-1-1-1:2:30.300123456"),
         param("single_byte_string_spec", "STRING[1]"),

--- a/blark/tests/test_transformer.py
+++ b/blark/tests/test_transformer.py
@@ -247,6 +247,7 @@ def test_bool_literal_roundtrip(name, value, expected):
         param("simple_type_declaration", "TypeName : REFERENCE TO INT"),
         param("simple_type_declaration", "TypeName : POINTER TO INT"),
         param("simple_type_declaration", "TypeName : POINTER TO POINTER TO INT"),
+        param("simple_type_declaration", "TypeName : REFERENCE TO POINTER TO INT"),
         param("simple_type_declaration", "TypeName EXTENDS a.b : POINTER TO INT"),
         param("subrange_type_declaration", "TypeName : INT (1..2)"),
         param("subrange_type_declaration", "TypeName : INT (*) := 1"),

--- a/blark/tests/test_transformer.py
+++ b/blark/tests/test_transformer.py
@@ -495,6 +495,12 @@ def test_var_access_roundtrip(rule_name, value):
         )),
         param("global_var_declarations", tf.multiline_code_block(
             """
+            VAR_GLOBAL INTERNAL
+            END_VAR
+            """
+        )),
+        param("global_var_declarations", tf.multiline_code_block(
+            """
             VAR_GLOBAL CONSTANT
             END_VAR
             """

--- a/blark/tests/test_transformer.py
+++ b/blark/tests/test_transformer.py
@@ -983,6 +983,16 @@ def test_statement_roundtrip(rule_name, value):
         ),
         param("function_declaration", tf.multiline_code_block(
             """
+            FUNCTION FuncName : BOOL
+                VAR
+                    _c_epoch : dot.dateTime_t := (dateTime := DT#1970-1-1-0:0:0, uSec := 0);
+                END_VAR
+            END_FUNCTION
+            """),
+            id="default_with_datetime",
+        ),
+        param("function_declaration", tf.multiline_code_block(
+            """
             FUNCTION FuncName : Tc2_System.T_MaxString
                 VAR_INPUT
                     Ptr : POINTER TO UINT;

--- a/blark/tests/test_transformer.py
+++ b/blark/tests/test_transformer.py
@@ -246,6 +246,7 @@ def test_bool_literal_roundtrip(name, value, expected):
         param("simple_type_declaration", "TypeName : INT := 5 + 1 * (2)"),
         param("simple_type_declaration", "TypeName : REFERENCE TO INT"),
         param("simple_type_declaration", "TypeName : POINTER TO INT"),
+        param("simple_type_declaration", "TypeName : POINTER TO POINTER TO INT"),
         param("simple_type_declaration", "TypeName EXTENDS a.b : POINTER TO INT"),
         param("subrange_type_declaration", "TypeName : INT (1..2)"),
         param("subrange_type_declaration", "TypeName : INT (*) := 1"),

--- a/blark/tests/test_transformer.py
+++ b/blark/tests/test_transformer.py
@@ -260,6 +260,7 @@ def test_bool_literal_roundtrip(name, value, expected):
         param("array_type_declaration", "TypeName : ARRAY [1..2] OF INT := [1, 2]"),
         param("array_type_declaration", "TypeName : ARRAY [1..2, 3..4] OF INT := [2(3), 3(4)]"),
         param("array_type_declaration", "TypeName : ARRAY [1..2, 3..4] OF Tc.SomeType"),
+        param("array_type_declaration", "TypeName : ARRAY [1..2, 3..4] OF Tc.SomeType(someInput := 3)"),  # noqa: E501
         param("structure_type_declaration", "TypeName :\nSTRUCT\nEND_STRUCT"),
         param("structure_type_declaration", "TypeName EXTENDS Other.Type :\nSTRUCT\nEND_STRUCT"),
         param("structure_type_declaration", "TypeName : POINTER TO\nSTRUCT\nEND_STRUCT"),

--- a/blark/transform.py
+++ b/blark/transform.py
@@ -1606,9 +1606,7 @@ class FunctionCall(Expression):
         )
 
     def __str__(self) -> str:
-        parameters = ""
-        if self.parameters != []:
-            parameters = ", ".join(str(param) for param in self.parameters)
+        parameters = ", ".join(str(param) for param in self.parameters)
         return f"{self.name}({parameters})"
 
 

--- a/blark/transform.py
+++ b/blark/transform.py
@@ -206,6 +206,15 @@ class VariableAttributes(_FlagHelper, enum.Flag):
     persistent = 0b0000_1000
 
 
+@_rule_handler("global_variable_attributes")
+class GlobalVariableAttributes(_FlagHelper, enum.Flag):
+    constant = 0b0000_0001
+    retain = 0b0000_0010
+    non_retain = 0b0000_0100
+    persistent = 0b0000_1000
+    internal = 0b0001_0000
+
+
 @_rule_handler(
     "access_specifier",
 )
@@ -3164,3 +3173,7 @@ if apischema is not None:
     @apischema.deserializer
     def _var_attrs_deserializer(attrs: int) -> VariableAttributes:
         return VariableAttributes(attrs)
+
+    @apischema.deserializer
+    def _global_var_attrs_deserializer(attrs: int) -> GlobalVariableAttributes:
+        return GlobalVariableAttributes(attrs)

--- a/blark/transform.py
+++ b/blark/transform.py
@@ -626,12 +626,12 @@ class IndirectionType(Literal):
     meta: Optional[Meta] = meta_field()
 
     @staticmethod
-    def from_lark(token: Optional[lark.Token]) -> IndirectionType:
+    def from_lark(*tokens: Tuple[lark.Token]) -> IndirectionType:
         pointer_depth = 0
         reference = False
-        if token is not None:
-            pointer_depth = token.count("POINTER TO")
-            reference = token.startswith("REFERENCE TO")
+        if len(tokens) > 0:
+            pointer_depth = tokens.count("POINTER TO")
+            reference = "REFERENCE TO" in tokens
         return IndirectionType(
             pointer_depth=pointer_depth,
             reference=reference

--- a/blark/transform.py
+++ b/blark/transform.py
@@ -478,13 +478,13 @@ class TimeOfDay(Literal):
     """Time of day literal value."""
     hour: lark.Token
     minute: lark.Token
-    second: lark.Token
+    second: Optional[lark.Token] = None
     meta: Optional[Meta] = meta_field()
 
     @property
     def value(self) -> str:
         """The time of day value."""
-        return f"{self.hour}:{self.minute}:{self.second}"
+        return join_if(f"{self.hour}:{self.minute}", ":", self.second)
 
     def __str__(self):
         return f"TIME_OF_DAY#{self.value}"

--- a/blark/transform.py
+++ b/blark/transform.py
@@ -1598,7 +1598,9 @@ class FunctionCall(Expression):
         )
 
     def __str__(self) -> str:
-        parameters = ", ".join(str(param) for param in self.parameters)
+        parameters = ""
+        if self.parameters != [None]:
+            parameters = ", ".join(str(param) for param in self.parameters)
         return f"{self.name}({parameters})"
 
 

--- a/blark/transform.py
+++ b/blark/transform.py
@@ -1597,6 +1597,9 @@ class FunctionCall(Expression):
         name: SymbolicVariable,
         *parameters: ParameterAssignment,
     ) -> FunctionCall:
+        # Condition parameters (which may be `None`) to represent empty tuple
+        if parameters == (None, ):
+            parameters = []
         return FunctionCall(
             name=name,
             parameters=list(parameters)
@@ -1604,7 +1607,7 @@ class FunctionCall(Expression):
 
     def __str__(self) -> str:
         parameters = ""
-        if self.parameters != [None]:
+        if self.parameters != []:
             parameters = ", ".join(str(param) for param in self.parameters)
         return f"{self.name}({parameters})"
 


### PR DESCRIPTION
I've found a number of little things that were causing some trouble while I was testing this project against a number of 61131 repositories, I've made a bunch of smaller, incremental branches for each stage of work, so if you'd prefer going through one at a time, let me know!

# Changes:
* Add Support of VAR_EXTERNAL in Functions.
* Allow DateTimes to exclude seconds/fractional-seconds (both appear to be legal options for 61131).
* Support Arrays of FunctionBlocks that use an FB_init inline. [example](https://github.com/engineerjoe440/blark/blob/ecffb0a5ebe4fa2bb5da4f701dd3b6a8932d5a21/blark/tests/source/array_of_objects.st#L4)
* Allow "Stray" semicolons that would otherwise have no effect.
* Allow Namespaced (dotted) access to structures in declaration when setting a default. [example](https://github.com/engineerjoe440/blark/blob/ecffb0a5ebe4fa2bb5da4f701dd3b6a8932d5a21/blark/tests/test_transformer.py#L1008)
* Separate Global Variable Attributes to allow inclusion of "INTERNAL".
* Allow function call with empty arguments. [example](https://github.com/engineerjoe440/blark/blob/ecffb0a5ebe4fa2bb5da4f701dd3b6a8932d5a21/blark/tests/test_transformer.py#L817)

#### Closing Thoughts:
Please do let me know if you'd rather take a piecemeal approach to this, I've still got all of the branches, and we can work each one in separately. If there's anything that I've missed (clearly I've done that a time or two before), please let me know! I'm happy to get this all cleaned up.

I'm finding this project very useful, thank you!