### PR TITLE
FIX: small regression after IndirectionType adjustments of #33

### DIFF
--- a/blark/tests/test_transformer.py
+++ b/blark/tests/test_transformer.py
@@ -538,6 +538,21 @@ def test_global_roundtrip(rule_name, value):
 @pytest.mark.parametrize(
     "rule_name, value",
     [
+        param("non_generic_type_name", "POINTER TO FBName"),
+        param("non_generic_type_name", "POINTER TO POINTER TO FBName"),
+        param("non_generic_type_name", "FBName"),
+        param("non_generic_type_name", "POINTER TO Package.FBName"),
+        param("non_generic_type_name", "POINTER TO POINTER TO Package.FBName"),
+        param("non_generic_type_name", "Package.FBName"),
+    ],
+)
+def test_type_name_roundtrip(rule_name, value):
+    roundtrip_rule(rule_name, value)
+
+
+@pytest.mark.parametrize(
+    "rule_name, value",
+    [
         param("function_block_type_declaration", tf.multiline_code_block(
             """
             FUNCTION_BLOCK fbName

--- a/blark/transform.py
+++ b/blark/transform.py
@@ -636,6 +636,11 @@ class IndirectionType:
     reference: bool
     meta: Optional[Meta] = meta_field()
 
+    @property
+    def is_indirect(self) -> bool:
+        """True if this denotes a pointer (of any depth) or a reference."""
+        return self.reference or (self.pointer_depth > 0)
+
     @staticmethod
     def from_lark(*tokens: lark.Token) -> IndirectionType:
         pointer_depth = 0
@@ -1124,7 +1129,7 @@ class DataType:
     meta: Optional[Meta] = meta_field()
 
     def __str__(self) -> str:
-        if self.indirection and self.indirection != IndirectionType.none:
+        if self.indirection and self.indirection.is_indirect:
             return f"{self.indirection} {self.type_name}"
         return f"{self.type_name}"
 


### PR DESCRIPTION
## Issue

`IndirectionType.none` went away, but we were still using it in `DataType`.

## Resolution

* Somewhat counter-intuitively, we can get an `IndirectionType` with a pointer depth of 0 and no reference flag set
* So this PR adds a simple property to replace that `none` check (`is_indirect`)
* This can then be used for the round-tripping of the data type
* Added test coverage of the rule