### PR TITLE
CI: code coverage via pytest-cov and codecov

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -40,7 +40,6 @@ jobs:
         fail_ci_if_error: true
         files: ./coverage.xml
         name: codecov-umbrella
-        path_to_write_report: ./coverage/codecov_report.txt
         verbose: true
 
     - name: Upload test artifacts
@@ -48,5 +47,4 @@ jobs:
       with:
         name: Artifacts
         path: |
-          ./coverage/*.txt
-          ./coverage.xml
+          ./coverage*

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -45,6 +45,6 @@ jobs:
     - name: Upload test artifacts
       uses: actions/upload-artifact@v3
       with:
-        name: Artifacts
+        name: ${{ github.sha }}_${{ matrix.os }}-${{ matrix.python-version }}_artifacts
         path: |
           ./coverage*

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -25,7 +25,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         python -m pip install -r requirements.txt
-        python -m pip install -r dev-requirements.txt
+        python -m pip install -r requirements-dev.txt
         python -m pip install .
 
     - name: Test with pytest

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -5,11 +5,14 @@ on: [push, pull_request]
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
     strategy:
       matrix:
         python-version: ["3.7", "3.8", "3.9", "3.10"]
+
+    env:
+      OS: ${{ matrix.os }}
+      PYTHON: ${{ matrix.python-version }}
 
     steps:
     - uses: actions/checkout@v2
@@ -17,12 +20,33 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
+
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
-        python -m pip install pytest
-        pip install .
+        python -m pip install -r requirements.txt
+        python -m pip install -r dev-requirements.txt
+        python -m pip install .
+
     - name: Test with pytest
       run: |
-        pytest
+        pytest -v --cov=blark/ --cov-report=xml:coverage.xml
+
+    - name: Upload coverage to Codecov
+      uses: codecov/codecov-action@v2
+      with:
+        directory: ./coverage/reports/
+        env_vars: OS,PYTHON
+        fail_ci_if_error: true
+        files: ./coverage.xml
+        name: codecov-umbrella
+        path_to_write_report: ./coverage/codecov_report.txt
+        verbose: true
+
+    - name: Upload test artifacts
+      uses: actions/upload-artifact@v3
+      with:
+        name: Artifacts
+        path: |
+          ./coverage/*.txt
+          ./coverage.xml

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -11,7 +11,6 @@ jobs:
         python-version: ["3.7", "3.8", "3.9", "3.10"]
 
     env:
-      OS: ${{ matrix.os }}
       PYTHON: ${{ matrix.python-version }}
 
     steps:
@@ -36,7 +35,7 @@ jobs:
       uses: codecov/codecov-action@v2
       with:
         directory: ./coverage/reports/
-        env_vars: OS,PYTHON
+        env_vars: PYTHON
         fail_ci_if_error: true
         files: ./coverage.xml
         name: codecov-umbrella

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,2 @@
+pytest
+pytest-cov


### PR DESCRIPTION
* Add `requirements-dev` for development requirements
* Modify GitHub actions to cover the blark codebase
* Upload coverage artifacts to GitHub
* Upload coverage report to codecov.io