### PR TITLE
Feature/add continue statement to grammar

### DIFF
--- a/blark/iec.lark
+++ b/blark/iec.lark
@@ -729,6 +729,7 @@ _statement: ";"
           | while_statement
           | repeat_statement
           | exit_statement
+          | continue_statement
 
 
 // B.3.2.1
@@ -787,3 +788,5 @@ while_statement: "WHILE"i expression "DO"i statement_list "END_WHILE"i ";"*
 repeat_statement: "REPEAT"i statement_list "UNTIL"i expression "END_REPEAT"i ";"*
 
 exit_statement.1: "EXIT"i ";"*
+
+continue_statement.1: "CONTINUE"i ";"*

--- a/blark/tests/test_transformer.py
+++ b/blark/tests/test_transformer.py
@@ -769,6 +769,16 @@ def test_type_name_roundtrip(rule_name, value):
             END_FUNCTION_BLOCK
             """
         )),
+        param("function_block_type_declaration", tf.multiline_code_block(
+            """
+            FUNCTION_BLOCK fbName
+                Method();
+                IF 1 THEN
+                    CONTINUE;
+                END_IF
+            END_FUNCTION_BLOCK
+            """
+        )),
         param("function_block_method_declaration", tf.multiline_code_block(
             """
             METHOD PRIVATE MethodName : RETURNTYPE

--- a/blark/tests/test_transformer.py
+++ b/blark/tests/test_transformer.py
@@ -1508,3 +1508,18 @@ def test_meta(code: str, comments: List[str], pragmas: List[str]):
     found_comments, found_pragmas = meta.get_comments_and_pragmas()
     assert [str(comment) for comment in found_comments] == comments
     assert [str(pragma) for pragma in found_pragmas] == pragmas
+
+
+@pytest.mark.parametrize(
+    "statement, cls",
+    [
+        ("CONTINUE;", tf.ContinueStatement),
+        ("EXIT;", tf.ExitStatement),
+        ("RETURN;", tf.ReturnStatement),
+    ]
+)
+def test_statement_priority(statement: str, cls: type):
+    transformed = roundtrip_rule("statement_list", statement)
+    assert isinstance(transformed, tf.StatementList)
+    transformed_statement, = transformed.statements
+    assert isinstance(transformed_statement, cls)

--- a/blark/transform.py
+++ b/blark/transform.py
@@ -2800,6 +2800,15 @@ class ExitStatement(Statement):
 
 
 @dataclass
+@_rule_handler("continue_statement", comments=True)
+class ContinueStatement(Statement):
+    meta: Optional[Meta] = meta_field()
+
+    def __str__(self):
+        return "CONTINUE;"
+
+
+@dataclass
 @_rule_handler("return_statement", comments=True)
 class ReturnStatement(Statement):
     meta: Optional[Meta] = meta_field()


### PR DESCRIPTION
## Related Issues:
* #47 

This should add support of the `CONTINUE` statement.

*Notes:* Seems that the tests are failing, but they appear to have been failing prior to changes, as well. Open to thoughts, there!