### PR TITLE
CI: updates to GitHub Actions and pre-commit fixes

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -2,9 +2,7 @@ name: lint
 
 on:
   push:
-    branches:
-      - master
-  pull_request: {}
+  pull_request:
 
 jobs:
   lint:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -9,12 +9,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Setup Python
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v4
         with:
           python-version: "3.10"
-          architecture: x64
+          check-latest: true
+
       - name: Checkout Repo Source
-        uses: actions/checkout@master
+        uses: actions/checkout@v3
+
       - name: Install flake8
         run: pip install flake8
       # https://github.com/marketplace/actions/flake8-action

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -1,0 +1,81 @@
+name: pre-commit check
+
+# Based on https://github.com/pcdshub/pcds-ci-helpers/blob/master/.github/workflows/pre-commit.yml
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  pre-commit:
+    runs-on: ubuntu-20.04
+
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Configure the matcher to annotate the diff
+      run: |
+        # Ref: https://github.com/actions/toolkit/blob/main/docs/problem-matchers.md
+        cat > "$HOME/flake8_problem_matcher.json" <<'EOF'
+        {
+            "problemMatcher": [
+                {
+                    "owner": "flake8_error",
+                    "severity": "error",
+                    "pattern": [
+                        {
+                            "regexp": "^(.+):(\\d+):(\\d+): (E\\d+) (.+)$",
+                            "file": 1,
+                            "line": 2,
+                            "column": 3,
+                            "code": 4,
+                            "message": 5
+                        }
+                    ]
+                },
+                {
+                    "owner": "flake8_warning",
+                    "severity": "warning",
+                    "pattern": [
+                        {
+                            "regexp": "^(.+):(\\d+):(\\d+): (W\\d+) (.+)$",
+                            "file": 1,
+                            "line": 2,
+                            "column": 3,
+                            "code": 4,
+                            "message": 5
+                        }
+                    ]
+                }
+            ]
+        }
+        EOF
+        echo "::add-matcher::$HOME/flake8_problem_matcher.json"
+
+    - name: Install pre-commit
+      run: |
+        python -m pip install pre-commit
+
+    - name: List Python package versions
+      run: |
+        python -m pip freeze --local
+
+    - name: Check for pre-commit configuration
+      run: |
+        if [ ! -f ".pre-commit-config.yaml" ]; then
+          echo "::error::No pre-commit configuration found!"
+          exit 1
+        fi
+
+    - name: Switch to temporary branch
+      run: |
+        # This is to avoid no-commit-to-branch from failing us when this is run
+        # on master.
+        git checkout -b _pre_commit_check_branch
+
+    - name: Check pre-commit usage
+      run: |
+        pre-commit run \
+          --show-diff-on-failure \
+          --color=always \
+          --all-files

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -3,9 +3,10 @@ name: pytest
 
 on:
   push:
-    branches:
-      - master
-  pull_request: {}
+  pull_request:
+  release:
+    types:
+      - published
 
 jobs:
   build:

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -40,7 +40,7 @@ jobs:
         pytest -v --cov=blark/ --cov-report=xml:coverage.xml
 
     - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v2
+      uses: codecov/codecov-action@v3
       with:
         directory: ./coverage/reports/
         env_vars: PYTHON

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -11,8 +11,9 @@ jobs:
   build:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10"]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
 
     env:
       PYTHON: ${{ matrix.python-version }}

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -20,11 +20,13 @@ jobs:
       PYTHON: ${{ matrix.python-version }}
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
+
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
+        check-latest: true
 
     - name: Install dependencies
       run: |

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -9,7 +9,8 @@ on:
       - published
 
 jobs:
-  build:
+  pytest:
+    name: Python ${{ matrix.python-version }} testing
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -53,6 +53,6 @@ jobs:
     - name: Upload test artifacts
       uses: actions/upload-artifact@v3
       with:
-        name: ${{ github.sha }}_${{ matrix.os }}-${{ matrix.python-version }}_artifacts
+        name: coverage-${{ github.sha }}_${{ matrix.os }}-${{ matrix.python-version }}
         path: |
           ./coverage*

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,14 @@
 # See https://pre-commit.com for more information
 # See https://pre-commit.com/hooks.html for more hooks
+
+exclude: |
+  (?x)^(
+    blark/tests/POUs/.*|
+    blark/tests/source/.*|
+    blark/_version.py|
+    versioneer.py
+  )$
+
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.4.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,7 +16,7 @@ repos:
     -   id: check-yaml
         exclude: '^(conda-recipe/meta.yaml)$'
 
--   repo: https://gitlab.com/pycqa/flake8.git
+-   repo: https://github.com/pycqa/flake8.git
     rev: 3.9.2
     hooks:
     -   id: flake8

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,7 @@
 # See https://pre-commit.com/hooks.html for more hooks
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.0.1
+    rev: v4.4.0
     hooks:
     -   id: no-commit-to-branch
     -   id: trailing-whitespace
@@ -17,11 +17,11 @@ repos:
         exclude: '^(conda-recipe/meta.yaml)$'
 
 -   repo: https://github.com/pycqa/flake8.git
-    rev: 3.9.2
+    rev: 6.0.0
     hooks:
     -   id: flake8
 
 -   repo: https://github.com/timothycrosley/isort
-    rev: 5.9.2
+    rev: 5.12.0
     hooks:
     -   id: isort

--- a/blark/transform.py
+++ b/blark/transform.py
@@ -697,6 +697,9 @@ class VariableLocationPrefix(str, Enum):
     output = "Q"
     memory = "M"
 
+    def __str__(self) -> str:
+        return self.value
+
 
 class VariableSizePrefix(str, Enum):
     bit = "X"
@@ -704,6 +707,9 @@ class VariableSizePrefix(str, Enum):
     word_16 = "W"
     dword_32 = "D"
     lword_64 = "L"
+
+    def __str__(self) -> str:
+        return self.value
 
 
 @dataclass


### PR DESCRIPTION
* 3.8 job is failing due to apischema import. I'm unable to reproduce this locally
* Regardless of that failure, we don't want the entire test suite failing
* As such, `fail-fast` was disabled

Separately:
* Deprecated/old reusable jobs were updated
* A pre-commit check job was added (which duplicates some of the linter job, but that's OK for now)
* Fixed pre-commit URL for flake8 (gitlab->github) and excluded the PLC source directories globally
* Added a Python 3.11 job to the matrix