### PR TITLE
Add Support of Chained Method/Function Calls

### DIFF
--- a/blark/iec.lark
+++ b/blark/iec.lark
@@ -722,7 +722,7 @@ _statement: ";"
           | reset_statement
           | reference_assignment_statement
           | return_statement
-          | function_call_statement_list
+          | chained_function_call_statement
           | function_call_statement
           | if_statement
           | case_statement
@@ -753,7 +753,7 @@ return_statement.1: "RETURN"i ";"*
 
 function_call_statement: function_call ";"+
 
-function_call_statement_list: function_call ("." function_call)+ ";"+
+chained_function_call_statement: function_call ("." function_call)+ ";"+
 
 param_assignment: [ LOGICAL_NOT ] variable_name "=>" [ expression ] -> output_parameter_assignment
                 | variable_name ":=" [ expression ]

--- a/blark/iec.lark
+++ b/blark/iec.lark
@@ -722,6 +722,7 @@ _statement: ";"
           | reset_statement
           | reference_assignment_statement
           | return_statement
+          | function_call_statement_list
           | function_call_statement
           | if_statement
           | case_statement
@@ -751,6 +752,8 @@ return_statement.1: "RETURN"i ";"*
 // return_statement: priority > 0 so that it doesn't clash with no_op_statement
 
 function_call_statement: function_call ";"+
+
+function_call_statement_list: function_call ("." function_call)+ ";"+
 
 param_assignment: [ LOGICAL_NOT ] variable_name "=>" [ expression ] -> output_parameter_assignment
                 | variable_name ":=" [ expression ]

--- a/blark/tests/source/object_oriented_dotaccess.st
+++ b/blark/tests/source/object_oriented_dotaccess.st
@@ -9,4 +9,11 @@ uut.DoSomething(input_1:='foo', input_2:='bar')
    .DoSomethingElse(input_1:=5)
    .Finish();
 
+// Or perhaps something that's a little more tame
+uut.DoSomething(input_1:='foo', input_2:='bar')
+   .DoSomethingElse(input_1:=5).Finish();
+
+// Or something tamer, still
+uut.DoSomething(input_1:='foo', input_2:='bar').DoSomethingElse(input_1:=5).Finish();
+
 END_PROGRAM

--- a/blark/tests/source/object_oriented_dotaccess.st
+++ b/blark/tests/source/object_oriented_dotaccess.st
@@ -1,0 +1,12 @@
+(* This program uses some object-oriented function-block with multiline access. *)
+PROGRAM oop_test
+VAR
+        uut : SomeFunctionBlock;
+END_VAR
+
+// Use an object that has a different method called on each line
+uut.DoSomething(input_1:='foo', input_2:='bar')
+   .DoSomethingElse(input_1:=5)
+   .Finish();
+
+END_PROGRAM

--- a/blark/tests/test_transformer.py
+++ b/blark/tests/test_transformer.py
@@ -1073,6 +1073,11 @@ def test_action_roundtrip(rule_name, value):
             END_FOR
             """
         )),
+        param("function_call_statement_list", tf.multiline_code_block(
+            """
+            uut.call1().call2().call3.call4().done();
+            """
+        )),
     ],
 )
 def test_statement_roundtrip(rule_name, value):

--- a/blark/tests/test_transformer.py
+++ b/blark/tests/test_transformer.py
@@ -1073,7 +1073,7 @@ def test_action_roundtrip(rule_name, value):
             END_FOR
             """
         )),
-        param("function_call_statement_list", tf.multiline_code_block(
+        param("chained_function_call_statement", tf.multiline_code_block(
             """
             uut.call1().call2().call3.call4().done();
             """

--- a/blark/transform.py
+++ b/blark/transform.py
@@ -2605,7 +2605,7 @@ class FunctionCallStatement(Statement, FunctionCall):
 
 
 @dataclass
-@_rule_handler("function_call_statement_list")
+@_rule_handler("function_call_statement_list", comments=True)
 class FunctionCallStatementList(Statement):
     invocations: List[FunctionCall]
     meta: Optional[Meta] = meta_field()

--- a/blark/transform.py
+++ b/blark/transform.py
@@ -2612,7 +2612,6 @@ class FunctionCallStatementList(Statement):
 
     @staticmethod
     def from_lark(*invocations: FunctionCall) -> FunctionCallStatementList:
-        print(len(invocations), invocations)
         return FunctionCallStatementList(
             invocations=list(invocations)
         )

--- a/blark/transform.py
+++ b/blark/transform.py
@@ -2605,14 +2605,14 @@ class FunctionCallStatement(Statement, FunctionCall):
 
 
 @dataclass
-@_rule_handler("function_call_statement_list", comments=True)
-class FunctionCallStatementList(Statement):
+@_rule_handler("chained_function_call_statement", comments=True)
+class ChainedFunctionCallStatement(Statement):
     invocations: List[FunctionCall]
     meta: Optional[Meta] = meta_field()
 
     @staticmethod
-    def from_lark(*invocations: FunctionCall) -> FunctionCallStatementList:
-        return FunctionCallStatementList(
+    def from_lark(*invocations: FunctionCall) -> ChainedFunctionCallStatement:
+        return ChainedFunctionCallStatement(
             invocations=list(invocations)
         )
 

--- a/blark/transform.py
+++ b/blark/transform.py
@@ -2605,6 +2605,24 @@ class FunctionCallStatement(Statement, FunctionCall):
 
 
 @dataclass
+@_rule_handler("function_call_statement_list")
+class FunctionCallStatementList(Statement):
+    invocations: List[FunctionCall]
+    meta: Optional[Meta] = meta_field()
+
+    @staticmethod
+    def from_lark(*invocations: FunctionCall) -> FunctionCallStatementList:
+        print(len(invocations), invocations)
+        return FunctionCallStatementList(
+            invocations=list(invocations)
+        )
+
+    def __str__(self) -> str:
+        invoc = ".".join(str(invocation) for invocation in self.invocations)
+        return f"{invoc};"
+
+
+@dataclass
 @_rule_handler("else_if_clause", comments=True)
 class ElseIfClause:
     if_expression: Expression


### PR DESCRIPTION
## Issues Addressed

* #54 

## Changes

* Add support of chained function-call/method-call statements with new `function_call_statement_list` grammar.

### Closing Thoughts

I think this is a fairly reasonable way to address this item, but I'm very open to comments or suggestions. I think it's possible to combine the original `function_call_statement` and this new `function_call_statement_list` but I left the original one for consistency sake. Let me know what you think!