### PR TITLE
Array Initializer

### DIFF
--- a/blark/iec.lark
+++ b/blark/iec.lark
@@ -439,7 +439,7 @@ structured_var_init_decl: var1_list ":" initialized_structure
 
 // Function blocks
 fb_decl: fb_decl_name_list ":" function_block_type_name [ ":=" structure_initialization ] -> fb_name_decl
-       | fb_decl_name_list ":" function_call                                              -> fb_invocation_decl
+       | fb_decl_name_list ":" function_call [ ":=" structure_initialization ]            -> fb_invocation_decl
 
 fb_decl_name_list: fb_name ( "," fb_name )*
 

--- a/blark/iec.lark
+++ b/blark/iec.lark
@@ -335,7 +335,8 @@ _array_spec_type: STRING_TYPE
 object_initializer_array: function_block_type_name "[" structure_initialization ( "," structure_initialization )* "]"
 
 array_initialization: "[" array_initial_element ( "," array_initial_element )* "]"
-                    | array_initial_element ( "," array_initial_element )*
+// Removed to allow correct parsing of FB attribute assignment - JS - 20230410
+//                    | array_initial_element ( "," array_initial_element )*
 
 array_initial_element: ( integer | enumerated_value ) "(" [ _array_initial_element ] ")" -> array_initial_element_count
                      | _array_initial_element

--- a/blark/iec.lark
+++ b/blark/iec.lark
@@ -330,6 +330,9 @@ array_specification: "ARRAY"i "[" subrange ( "," subrange )* "]" "OF"i _array_sp
 _array_spec_type: STRING_TYPE
                 | function_call
                 | non_generic_type_name
+                | object_initializer_array
+
+object_initializer_array: function_block_type_name "[" structure_initialization ( "," structure_initialization )* "]"
 
 array_initialization: "[" array_initial_element ( "," array_initial_element )* "]"
                     | array_initial_element ( "," array_initial_element )*

--- a/blark/tests/source/array_initializer.st
+++ b/blark/tests/source/array_initializer.st
@@ -20,7 +20,6 @@ VAR
         (instanceName := 'seventeen'),
         (instanceName := 'eighteen')
     ];
-    fbSample  : FB_Sample(nInitParam := 1) := (nInput := 2, nMyProperty := 3);
     aSample   : ARRAY[1..2] OF FB_Sample[(nInitParam := 4), (nInitParam := 7)]
                             := [(nInput := 5, nMyProperty := 6), (nInput := 8, nMyProperty := 9)];
 END_VAR

--- a/blark/tests/source/array_initializer.st
+++ b/blark/tests/source/array_initializer.st
@@ -1,0 +1,28 @@
+(* This program creates an array of objects using array initialization. *)
+PROGRAM oop_test
+VAR
+    runners : ARRAY[RunnerTasks.RUNNER_START+1..RunnerTasks.RUNNER_END-1] OF FB_Runner[
+        (instanceName := 'one'),
+        (instanceName := 'two'),
+        (instanceName := 'three'),
+        (instanceName := 'four'),
+        (instanceName := 'five'),
+        (instanceName := 'six'),
+        (instanceName := 'seven'),
+        (instanceName := 'eight'),
+        (instanceName := 'nine'),
+        (instanceName := 'ten'),
+        (instanceName := 'elevin'),
+        (instanceName := 'thirteen'),
+        (instanceName := 'fourteen'),
+        (instanceName := 'fifteen'),
+        (instanceName := 'sixteen'),
+        (instanceName := 'seventeen'),
+        (instanceName := 'eighteen')
+    ];
+    fbSample  : FB_Sample(nInitParam := 1) := (nInput := 2, nMyProperty := 3);
+    aSample   : ARRAY[1..2] OF FB_Sample[(nInitParam := 4), (nInitParam := 7)]
+                            := [(nInput := 5, nMyProperty := 6), (nInput := 8, nMyProperty := 9)];
+END_VAR
+
+END_PROGRAM

--- a/blark/tests/source/fb_initializer.st
+++ b/blark/tests/source/fb_initializer.st
@@ -1,0 +1,7 @@
+(* This program creates a function block instance with initialization. *)
+PROGRAM oop_test
+VAR
+    fbSample  : FB_Sample(nInitParam := 1) := (nInput := 2, nMyProperty := 3);
+END_VAR
+
+END_PROGRAM

--- a/blark/tests/test_transformer.py
+++ b/blark/tests/test_transformer.py
@@ -354,10 +354,6 @@ def test_expression_roundtrip(rule_name, value):
             END_VAR
             """,
             ),
-            marks=pytest.mark.xfail(reason="TODO; this is valid grammar, I think"),
-            # Identical paths:
-            #   fb_name_decl -> structure_initialization
-            #   array_initialization -> array_initial_element -> structure_initialization
         ),
     ],
 )
@@ -445,6 +441,7 @@ def test_output_roundtrip(rule_name, value):
                 fbTest : FB_Test(1, 2, 3);
                 fbTest : FB_Test(A := 1, B := 2, C => 3);
                 fbTest : FB_Test(1, 2, A := 1, B := 2, C => 3);
+                fbTest : FB_Test(initializer := 5) := (A := 1, B := 2, C := 3);
                 fbTest : FB_Test := (1, 2, 3);
             END_VAR
             """

--- a/blark/transform.py
+++ b/blark/transform.py
@@ -1166,7 +1166,7 @@ class IndirectSimpleSpecification:
 @dataclass
 @_rule_handler("array_specification")
 class ArraySpecification:
-    type: Union[DataType, FunctionCall]
+    type: Union[DataType, FunctionCall, ObjectInitializerArray]
     subranges: List[Subrange]
     meta: Optional[Meta] = meta_field()
 
@@ -1233,12 +1233,34 @@ class ArrayInitialization:
     meta: Optional[Meta] = meta_field()
 
     @staticmethod
-    def from_lark(*elements: ArrayInitialElement):
+    def from_lark(*elements: ArrayInitialElement) -> ArrayInitialization:
         return ArrayInitialization(list(elements))
 
     def __str__(self) -> str:
         elements = ", ".join(str(element) for element in self.elements)
         return f"[{elements}]"
+
+
+@dataclass
+@_rule_handler("object_initializer_array")
+class ObjectInitializerArray:
+    name: SymbolicVariable
+    initializers: List[ArrayInitialElement]
+    meta: Optional[Meta] = meta_field()
+
+    @staticmethod
+    def from_lark(
+        function_block_type_name: SymbolicVariable,
+        *initializers: List[StructureInitialization]
+    ) -> ObjectInitializerArray:
+        return ObjectInitializerArray(
+            name=function_block_type_name,
+            initializers=list(initializers)
+        )
+
+    def __str__(self) -> str:
+        initializers = ", ".join([f"({init})" for init in self.initializers])
+        return f"{self.name}[{initializers}]"
 
 
 @dataclass

--- a/blark/transform.py
+++ b/blark/transform.py
@@ -1245,7 +1245,7 @@ class ArrayInitialization:
 @_rule_handler("object_initializer_array")
 class ObjectInitializerArray:
     name: SymbolicVariable
-    initializers: List[ArrayInitialElement]
+    initializers: List[StructureInitialization]
     meta: Optional[Meta] = meta_field()
 
     @staticmethod

--- a/blark/transform.py
+++ b/blark/transform.py
@@ -1789,11 +1789,13 @@ class FunctionBlockNameDeclaration(FunctionBlockDeclaration):
 class FunctionBlockInvocationDeclaration(FunctionBlockDeclaration):
     variables: List[lark.Token]
     init: FunctionCall
+    defaults: Optional[StructureInitialization] = None
     meta: Optional[Meta] = meta_field()
 
     def __str__(self) -> str:
         variables = ", ".join(self.variables)
-        return f"{variables} : {self.init}"
+        name_and_type = f"{variables} : {self.init}"
+        return join_if(name_and_type, " := ", self.defaults)
 
 
 @as_tagged_union


### PR DESCRIPTION
## Related Issues

* #44

## Changes

* Add support for array initializer for function-block objects.
* Enhance function-block declaration to support setting structured attributes (`VAR_INPUT` and `VAR_IN_OUT`).

### Closing Thoughts

Hopefully with these additions, some of the "in-the-wild" code we've come across will get patched up and parse as we expect. :smile: