### PR TITLE
Support Dereferenced Function/Method Returns in Grammar

### DIFF
--- a/blark/iec.lark
+++ b/blark/iec.lark
@@ -708,7 +708,7 @@ UNARY_OPERATOR: LOGICAL_NOT
               | MINUS
               | PLUS
 
-function_call: symbolic_variable "(" [ param_assignment ( "," param_assignment )* ","? ] ")"
+function_call: symbolic_variable "(" [ param_assignment ( "," param_assignment )* ","? ] ")" DEREFERENCED?
 
 ?primary_expression: "(" expression ")"      -> parenthesized_expression
                    | function_call
@@ -749,7 +749,7 @@ reset_statement: _variable "R="i expression ";"+
 reference_assignment_statement: _variable "REF="i expression ";"+
 
 // method ::= expression [DEREFERENCED] '.' _identifier '(' ')';
-method_statement: symbolic_variable "(" ")" ";"+
+method_statement: symbolic_variable "(" ")" DEREFERENCED? ";"+
 
 // B.3.2.2
 return_statement.1: "RETURN"i ";"*

--- a/blark/tests/source/dereference_method.st
+++ b/blark/tests/source/dereference_method.st
@@ -1,0 +1,8 @@
+METHOD DoSomething
+VAR
+    Something : BOOL;
+END_VAR
+
+Something := anObject.WriteLine(THIS^.something.t, THIS^.GetTagName()^, INT_TO_STRING(BOOL_TO_INT(THIS^.someAttribute)));
+
+END_METHOD

--- a/blark/tests/test_transformer.py
+++ b/blark/tests/test_transformer.py
@@ -1072,7 +1072,17 @@ def test_action_roundtrip(rule_name, value):
         )),
         param("chained_function_call_statement", tf.multiline_code_block(
             """
-            uut.call1().call2().call3.call4().done();
+            uut.call1().call2().call3().call4().done();
+            """
+        )),
+        param("chained_function_call_statement", tf.multiline_code_block(
+            """
+            uut.call1()^.call2().call3()^.call4().done();
+            """
+        )),
+        param("chained_function_call_statement", tf.multiline_code_block(
+            """
+            uut.call1()^.call2(A := 1).call3(B := 2)^.call4().done();
             """
         )),
     ],


### PR DESCRIPTION
## Related Issues

* #57 

## Changes

* Added optional dereference (`^`) character to function and method call (return) statements.

### Closing Thoughts

These changes should make this all a bit more convenient, and should allow for syntax such as:

```pascal
uut.call1()^.call2(A := 1).call3(B := 2)^.call4().done();
```

Which can allow for chained method calls using dereferences on any returned pointers.