### PR TITLE
Support for Explicit Base 10 Integers

### DIFF
--- a/blark/iec.lark
+++ b/blark/iec.lark
@@ -64,7 +64,7 @@ integer_literal: [ INTEGER_TYPE_NAME "#" ] any_integer
             | SIGNED_INTEGER              -> signed_integer
             | integer
 
-integer: INTEGER
+integer: [ "10#" ] INTEGER
 
 real_literal: [ REAL_TYPE_NAME "#" ] /((\+|\-)?[0-9](_?[0-9])*)\.([0-9](_?[0-9])*)((e|E)(\+|\-)?([0-9](_?[0-9])*))?/
             | [ REAL_TYPE_NAME "#" ] /((\+|\-)?[0-9](_?[0-9])*)((e|E)(\+|\-)?([0-9](_?[0-9])*))/

--- a/blark/tests/test_transformer.py
+++ b/blark/tests/test_transformer.py
@@ -83,6 +83,7 @@ def test_check_unhandled_rules(grammar):
     [
         param("integer_literal", "-12", tf.Integer(value="-12")),
         param("integer_literal", "12", tf.Integer(value="12")),
+        param("integer_literal", "10#12", tf.Integer(value="12")),
         param("integer_literal", "INT#12", tf.Integer(value="12", type_name="INT")),
         param("integer_literal", "2#10010", tf.BinaryInteger(value="10010")),
         param("integer_literal", "8#22", tf.OctalInteger(value="22")),


### PR DESCRIPTION
## Issues Addressed

* #58 

## Changes

* Add optional explicit base-10 specifier for integers.


### Closing Thoughts

@klauer, you really made this one too easy! 😉 Thanks, again!