### PR TITLE
REF/ENH: standalone solution parser and rewrite of input/output format support

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.9", "3.10", "3.11"]
 
     env:
       PYTHON: ${{ matrix.python-version }}

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -22,6 +22,9 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+        submodules: 'recursive'
 
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v4

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "blark/tests/blark-twincat-root-example"]
+	path = blark/tests/twincat_root
+	url = https://github.com/klauer/blark-twincat-root-example

--- a/README.md
+++ b/README.md
@@ -113,7 +113,6 @@ Dump out a parsed and reformatted set of source code:
 
 ```bash
 $ blark format blark/tests/source/array_of_objects.st
-
 {attribute 'hide'}
 METHOD prv_Detection : BOOL
     VAR_IN_OUT

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Requirements
 ------------
 
 * [lark](https://github.com/lark-parser/lark) (for grammar-based parsing)
-* [pytmc](https://github.com/pcdshub/pytmc) (for directly loading TwinCAT projects)
+* [lxml](https://github.com/lxml/lxml) (for parsing TwinCAT projects)
 
 How to use it
 -------------

--- a/README.md
+++ b/README.md
@@ -11,24 +11,28 @@ or produce useful Python instances just yet.
 
 See [issues](https://github.com/klauer/blark/issues) for further details.
 
-## The plan
-
-As a fun side project, blark isn't at the top of my priority list.
-
-Once I get around to it, I hope to:
-
-- [x] Introduce user-friendly Python dataclasses for all PLC constructs
-- [x] Create a lark Transformer to take tokenized PLC code and map them onto
-  those dataclasses
-- [ ] Fix the grammar and improve it as I go
-- [ ] Python ``black``-style automatic code formatter?
-- [ ] Documentation generator in markdown?
-- [ ] Syntax highlighted source code output?
+As a fun side project, blark isn't at the top of my priority list.  For
+an idea of where the project is going, see the issues list.
 
 ## Requirements
 
 * [lark](https://github.com/lark-parser/lark) (for grammar-based parsing)
 * [lxml](https://github.com/lxml/lxml) (for parsing TwinCAT projects)
+
+## Capabilities
+
+* TwinCAT source code file parsing (``*.TcPOU`` and others)
+* TwinCAT project and solution loading
+* ``lark.Tree`` generation of any supported source code
+* Python dataclasses of supported source code, with introspection and code refactoring
+
+### Works-in-progress
+
+* Sphinx API documentation generation (a new Sphinx domain)
+* Code reformatting
+* "Dependency store" - recursively parse and inspect project dependencies
+* Summary generation - a layer on top of dataclasses to summarize source code details
+* Rewriting source code directly in TwinCAT source code files
 
 ## Installation
 
@@ -38,131 +42,177 @@ Installation is quick with Pip.
 pip install --upgrade blark
 ```
 
-## Quickstart
+### Quickstart (pip / virtualenv with venv)
 
-1. Preferably using non-system Python, set up an environment using, e.g., miniconda:
+1. Set up an environment using venv:
   ```bash
-  $ conda create -n blark-env -c conda-forge python=3.7 blark
+  $ python -m venv blark_venv
+  $ source blark_venv/bin/activate
+  ```
+2. Install the library with pip:
+  ```bash
+  $ python -m pip install blark
+  ```
+
+### Quickstart (Conda)
+
+1. Set up an environment using conda:
+  ```bash
+  $ conda create -n blark-env -c conda-forge python=3.10 pip blark
   $ conda activate blark-env
   ```
-2. Install the library (using conda or otherwise, these steps are the same)
+2. Install the library from conda:
   ```bash
-  $ pip install blark
+  $ conda install blark
   ```
-3. Run the parser or experimental formatter utility.  Supported file types
-   include those from TwinCAT3 projects ( ``.tsproj``, ``.sln``, ``.TcPOU``,
-   ``.TcGVL``).
+
+### Development install
+
+If you run into issues or wish to run an unreleased version of blark, you may
+install directly from this repository like so:
+```bash
+$ python -m pip install git+https://github.com/klauer/blark
+```
+
+## Sample runs
+
+Run the parser or experimental formatter utility.  Current supported file types
+include those from TwinCAT3 projects ( ``.tsproj``, ``.sln``, ``.TcPOU``,
+``.TcGVL``) and plain-text ``.st`` files.
 
 ```bash
-$ blark parse -vvv blark/tests/POUs/F_SetStateParams.TcPOU
-iec_source
-  function_declaration
-    F_SetStateParams
-    BOOL
-    function_var_blocks
-      input_declarations
-        None
-        var1_init_decl
-          var1_list
-            var1
-              variable_name
-                nStateRef
-                None
-              None
-          simple_spec_init
-            None
-            UDINT
-            None
+$ blark parse --print-tree blark/tests/POUs/F_SetStateParams.TcPOU
+function_declaration
+  None
+  F_SetStateParams
+  indirect_simple_specification
+    None
+    simple_specification        BOOL
+  input_declarations
+    None
+    var1_init_decl
+      var1_list
 ... (clipped) ...
 ```
 
-To interact with the Python dataclasses directly, use:
+To interact with the Python dataclasses directly, make sure IPython is
+installed first and then try:
 
 ```
 $ blark parse --interactive blark/tests/POUs/F_SetStateParams.TcPOU
 # Assuming IPython is installed, the following prompt will come up:
 
-In [1]: result.items[0].name
-Out[1]: Token('IDENTIFIER', 'F_SetStateParams')
+In [1]: results[0].identifier
+Out[1]: 'F_SetStateParams/declaration'
+
+In [2]: results[1].identifier
+Out[2]: 'F_SetStateParams/implementation'
 ```
 
 Dump out a parsed and reformatted set of source code:
 
 ```bash
+$ blark format blark/tests/source/array_of_objects.st
+
+{attribute 'hide'}
+METHOD prv_Detection : BOOL
+    VAR_IN_OUT
+        currentChannel : ARRAY [APhase..CPhase] OF class_baseVector(SIZEOF(vector_t), 0);
+    END_VAR
+END_METHOD
+```
+
+blark supports rewriting TwinCAT source code files directly as well:
+
+```bash
 $ blark format blark/tests/POUs/F_SetStateParams.TcPOU
-FUNCTION F_SetStateParams : BOOL
+
+<TcPlcObject Version="1.1.0.1" ProductVersion="3.1.4024.0">
+  <POU Name="F_SetStateParams" Id="{f9611d23-4bb5-422d-9f11-2cc94e61fc9e}" SpecialFunc="None">
+    <Declaration><![CDATA[FUNCTION F_SetStateParams : BOOL
     VAR_INPUT
         nStateRef : UDINT;
         rPosition : REAL;
         rTolerance : REAL;
         stBeamParams : ST_BeamParams;
-    END_VAR
-    VAR_IN_OUT
-        Table : FB_LinearDeviceStateTable;
-    END_VAR
-    VAR
-        stDeviceState : ST_DeviceState;
-    END_VAR
-    stDeviceState.nStateRef := nStateRef;
-    stDeviceState.rPosition := rPosition;
-    stDeviceState.rTolerance := rTolerance;
-    stDeviceState.stReqBeamParam := stBeamParams;
-    Table.A_Add(key := nStateRef, putValue := stDeviceState);
-    F_SetStateParams := Table.bOk;
-END_FUNCTION
+
+... (clipped) ...
 ```
 
-It is also possible to parse the source code into a tokenized SourceCode tree:
-
-```python
->>> import blark
->>> blark.parse_source_code(
-...     """
-...                 PROGRAM ProgramName
-...                 VAR_INPUT
-...                     iValue : INT;
-...                 END_VAR
-...                 VAR_ACCESS
-...                     AccessName : SymbolicVariable : TypeName READ_WRITE;
-...                 END_VAR
-...                 iValue := iValue + 1;
-...             END_PROGRAM
-... """
-... )
-SourceCode(items=[Program(name=Token('IDENTIFIER', 'ProgramName'), declarations=[InputDeclarations(attrs=None, items=[VariableOneInitDeclaration(variables=[DeclaredVariable(variable=SimpleVariable(name=Token('IDENTIFIER', 'iValue'), dereferenced=False), location=None)], init=TypeInitialization(indirection=None, spec=SimpleSpecification(type=Token('DOTTED_IDENTIFIER', 'INT')), value=None))]), AccessDeclarations(items=[AccessDeclaration(name=Token('IDENTIFIER', 'AccessName'), variable=SimpleVariable(name=Token('IDENTIFIER', 'SymbolicVariable'), dereferenced=False), type=DataType(indirection=None, type_name=Token('DOTTED_IDENTIFIER', 'TypeName')), direction=Token('READ_WRITE', 'READ_WRITE'))])], body=StatementList(statements=[AssignmentStatement(variables=[SimpleVariable(name=Token('IDENTIFIER', 'iValue'), dereferenced=False)], expression=BinaryOperation(left=SimpleVariable(name=Token('IDENTIFIER', 'iValue'), dereferenced=False), op=Token('ADD_OPERATOR', '+'), right=Integer(value=Token('INTEGER', '1'), type_name=None)))]))], filename=PosixPath('unknown'), raw_source='\n                PROGRAM ProgramName\n                VAR_INPUT\n                    iValue : INT;\n                END_VAR\n                VAR_ACCESS\n                    AccessName : SymbolicVariable : TypeName READ_WRITE;\n                END_VAR\n                iValue := iValue + 1;\n            END_PROGRAM\n')
-```
-
-Alternatively, if you only want the tree:
+It is also possible to parse the source code into a tokenized ``SourceCode``
+tree which supports code introspection and rewriting:
 
 ```python
 In [1]: import blark
 
-In [2]: parser = blark.parse.new_parser(start="function_block_body")
+In [2]: parsed = blark.parse_source_code(
+   ...:     """
+   ...: PROGRAM ProgramName
+   ...:     VAR_INPUT
+   ...:         iValue : INT;
+   ...:     END_VAR
+   ...:     VAR_ACCESS
+   ...:         AccessName : SymbolicVariable : TypeName READ_WRITE;
+   ...:     END_VAR
+   ...:     iValue := iValue + 1;
+   ...: END_PROGRAM
+   ...: """
+   ...: )
 
-In [3]: parser.parse(
-    ...:     """// Default return value to TRUE
-    ...: SerializeJson := TRUE;
-    ...:
-    ...: // Set to Root of Structure
-    ...: Root();
-    ...:
-    ...: SerializeJson := SerializeJson AND _serializedContent.Recycle();
-    ...:
-    ...: // Set up Initial States for Indices
-    ...: lastLevel := Current.LEVEL;
-    ...: outerType := Current.JSON_TYPE;
-    ...: """
-    ...: )
-Out[3]: Tree(...)
+# Access the lark Tree here:
+In [3]: parsed.tree.data
+Out[3]: Token('RULE', 'iec_source')
+
+# Or the transformed information:
+In [3]: transformed = parsed.transform()
+
+In [4]: program = transformed.items[0]
+
+In [5]: program.declarations[0].items[0].variables[0].name
+Out[5]: Token('IDENTIFIER', 'iValue')
 ```
 
-For some additional reference regarding this syntax, refer to
-[the comment here on issue #20](https://github.com/klauer/blark/issues/20#issuecomment-1099699641)
+The supported starting grammar rules for the reusable parser include:
+
+```
+"iec_source"
+"action"
+"data_type_declaration"
+"function_block_method_declaration"
+"function_block_property_declaration"
+"function_block_type_declaration"
+"function_declaration"
+"global_var_declarations"
+"program_declaration"
+"statement_list"
+```
+
+Other starting rules remain possible for advanced users, however a new parser
+must be created in that scenario and transformations are not supported.
+
+Additionally, please note that you should avoid creating parsers on-the-fly as
+there is a startup cost to re-parsing the grammar. Utilize the provided parser
+from ``blark.get_parser()`` whenever possible.
+
+```
+In [1]: import blark
+
+In [2]: parser = blark.new_parser(start=["any_integer"])
+
+In [3]: Tree('hex_integer', [Token('HEX_STRING', '1010')])
+```
 
 ## Adding Test Cases
 
 Presently, test cases are provided in two forms. Within the `blark/tests/`
 directory there are `POUs/` and `source/` directories.
+
+TwinCAT source code files belong in ``blark/tests/POUs``.
+Plain-text source code files (e.g., ``.st`` files) belong in
+``blark/tests/source``.
+
+Feel free to contribute your own test cases and we'll do our best to ensure
+that blark parses them (and continues to parse them) without issue.
 
 ## Acknowledgements
 

--- a/blark/__init__.py
+++ b/blark/__init__.py
@@ -1,7 +1,7 @@
 import pathlib
 
 from . import _version
-from .parse import get_parser, parse_project, parse_source_code
+from .parse import get_parser, new_parser, parse_project, parse_source_code
 from .solution import Project, Solution, TwincatTsProject
 from .transform import GrammarTransformer
 
@@ -15,10 +15,11 @@ GRAMMAR_FILENAME = MODULE_PATH / "iec.lark"
 __all__ = [
     "GRAMMAR_FILENAME",
     "GrammarTransformer",
+    "Project",
+    "Solution",
+    "TwincatTsProject",
     "get_parser",
+    "new_parser",
     "parse_project",
     "parse_source_code",
-    "Solution",
-    "Project",
-    "TwincatTsProject",
 ]

--- a/blark/__init__.py
+++ b/blark/__init__.py
@@ -1,6 +1,6 @@
 import pathlib
 
-from . import _version
+from . import _version, plain
 from .parse import get_parser, new_parser, parse_project, parse_source_code
 from .solution import Project, Solution, TwincatTsProject
 from .transform import GrammarTransformer
@@ -11,6 +11,8 @@ MODULE_PATH = pathlib.Path(__file__).parent
 del pathlib
 
 GRAMMAR_FILENAME = MODULE_PATH / "iec.lark"
+
+plain._register()
 
 __all__ = [
     "GRAMMAR_FILENAME",

--- a/blark/__init__.py
+++ b/blark/__init__.py
@@ -2,6 +2,7 @@ import pathlib
 
 from . import _version
 from .parse import get_parser, parse_project, parse_source_code
+from .solution import Project, Solution, TwincatTsProject
 from .transform import GrammarTransformer
 
 __version__ = _version.get_versions()["version"]
@@ -17,4 +18,7 @@ __all__ = [
     "get_parser",
     "parse_project",
     "parse_source_code",
+    "Solution",
+    "Project",
+    "TwincatTsProject",
 ]

--- a/blark/__main__.py
+++ b/blark/__main__.py
@@ -1,3 +1,4 @@
 from .main import main
 
-main()
+if __name__ == "__main__":
+    main()

--- a/blark/dependency_store.py
+++ b/blark/dependency_store.py
@@ -4,13 +4,14 @@ TwinCAT project dependency handling.
 from __future__ import annotations
 
 import dataclasses
-import distutils.version
 import functools
 import json
 import logging
 import pathlib
 from dataclasses import dataclass
 from typing import Any, Dict, Generator, List, Optional, Tuple, Union
+
+import packaging.version
 
 from . import parse
 from . import transform as tf
@@ -70,14 +71,12 @@ class DependencyStoreLibrary:
         pathlib.Path
         """
 
-        def get_version(path):
+        def get_version(path: pathlib.Path) -> Optional[packaging.version.Version]:
             try:
-                version = path.name.lstrip("v").replace("-", ".")
-                version = tuple(distutils.version.LooseVersion(version).version)
-                if isinstance(version[0], int):
-                    return version
+                version_string = path.name.lstrip("v").replace("-", ".")
+                return packaging.version.parse(version_string)
             except Exception:
-                ...
+                return None
 
         project_root = root / self.path
 

--- a/blark/dependency_store.py
+++ b/blark/dependency_store.py
@@ -298,7 +298,7 @@ class PlcProjectMetadata:
                 continue
 
             for item in source.contents.to_blark():
-                for code_obj in parse.parse_item(item, transform=True):
+                for code_obj in parse.parse_item(item):
                     if code_obj.exception is not None:
                         logger.debug(
                             "Failed to load: %s %s", code_obj.filename, code_obj
@@ -310,7 +310,8 @@ class PlcProjectMetadata:
                         code_obj.filename
                     )
                     summary = CodeSummary.from_source(
-                        code_obj.transform(), filename=code_obj.filename
+                        code_obj.transform(),
+                        filename=code_obj.filename,
                     )
                     combined_summary.append(summary)
 

--- a/blark/format.py
+++ b/blark/format.py
@@ -40,11 +40,11 @@ def build_arg_parser(argparser=None):
         help="On failure, still return the results tree"
     )
 
-    # argparser.add_argument(
-    #     "--output-format",
-    #     type=str,
-    #     help="Output file format"
-    # )
+    argparser.add_argument(
+        "--output-format",
+        type=str,
+        help="Output file format"
+    )
 
     argparser.add_argument(
         "--in-place",
@@ -61,6 +61,7 @@ def main(
     debug: bool = False,
     interactive: bool = False,
     in_place: bool = False,
+    output_format: str = "input",
 ):
     result_by_filename = parse_main(
         filename, verbose=verbose, debug=debug, interactive=interactive

--- a/blark/format.py
+++ b/blark/format.py
@@ -68,6 +68,7 @@ def main(
 
     for filename, results in result_by_filename.items():
         for res in results:
+            print()
             item = res.item
             if item is None:
                 continue
@@ -89,13 +90,13 @@ def main(
                 else:
                     print(formatted_code)
             elif isinstance(user, SupportsWrite):
+                contents = user.to_file_contents()
                 if in_place:
-                    contents = user.to_file_contents()
                     mode = "wb" if isinstance(contents, bytes) else "wt"
                     with open(filename, mode) as fp:
                         fp.write(contents)
                 else:
-                    print(formatted_code)
+                    print(contents.decode())
             else:
                 print(formatted_code)
 

--- a/blark/format.py
+++ b/blark/format.py
@@ -3,12 +3,22 @@
 source code files.
 """
 import argparse
+import logging
+import pathlib
+import sys
+from typing import Any, List, Optional, Tuple, Union
 
+from blark import output
+
+from . import transform as tf
+from .output import OutputBlock
+from .parse import ParseResult
 from .parse import main as parse_main
-from .typing import SupportsCustomSave, SupportsRewrite, SupportsWrite
 from .util import AnyPath
 
 DESCRIPTION = __doc__
+
+logger = logging.getLogger(__name__)
 
 
 def build_arg_parser(argparser=None):
@@ -28,6 +38,12 @@ def build_arg_parser(argparser=None):
     )
 
     argparser.add_argument(
+        "-if",
+        "--input-format",
+        type=str,
+        help="Output file format, if not the same as the input format",
+    )
+    argparser.add_argument(
         "--verbose",
         "-v",
         action="count",
@@ -36,23 +52,115 @@ def build_arg_parser(argparser=None):
     )
 
     argparser.add_argument(
-        "--debug", action="store_true",
-        help="On failure, still return the results tree"
+        "--indent",
+        default="    ",
+        help="Single indent to reformat with",
     )
 
     argparser.add_argument(
+        "--debug",
+        action="store_true",
+        help="On failure, still return the results tree",
+    )
+
+    argparser.add_argument(
+        "--overwrite",
+        action="store_true",
+        help="Overwrite existing files",
+    )
+
+    argparser.add_argument(
+        "--write-to",
+        type=str,
+        help="Write formatted contents to this path",
+    )
+
+    argparser.add_argument(
+        "-of",
         "--output-format",
         type=str,
-        help="Output file format"
+        help="Output file format, if not the same as the input format",
     )
-
-    argparser.add_argument(
-        "--in-place",
-        action="store_true",
-        help="Write formatted contents back to the file"
-    )
-
     return argparser
+
+
+def reformat_code(
+    code: tf.SourceCode,
+) -> str:
+    """Reformat the code with the provided settings."""
+    # For anyone following at home, this is not a "good" formatting
+    # of the output - just a consistent output formatting.
+    # Opinionated, stylized output remains a TODO.
+    return str(code)
+
+
+def dump_source_to_console(source: Union[bytes, str], encoding: str = "utf-8") -> None:
+    if isinstance(source, bytes):
+        print(source.decode(encoding, errors="replace"))
+    else:
+        print(source)
+
+
+def write_source_to_file(
+    filename: pathlib.Path,
+    source: Union[bytes, str],
+    encoding: str = "utf-8",
+    overwrite: bool = False,
+) -> None:
+    if filename.exists() and not overwrite:
+        raise ValueError(
+            f"File would be overwritten: {filename} "
+            f"if this is OK use --overwrite"
+        )
+
+    if isinstance(source, str):
+        # NOTE: if this is undesirable, make your output handler
+        # return bytes instead of a string
+        source = source.encode(encoding)
+
+    with open(filename, "wb") as fp:
+        fp.write(source)
+
+
+def determine_output_filename(
+    input_filename: pathlib.Path,
+    write_to: Optional[pathlib.Path],
+) -> pathlib.Path:
+    if write_to:
+        output_filename = pathlib.Path(write_to)
+        if output_filename.is_dir():
+            return output_filename / input_filename.name
+        return output_filename
+
+    return input_filename
+
+
+def get_reformatted_code_blocks(
+    results: List[ParseResult],
+    raise_on_error: bool = True,
+) -> List[OutputBlock]:
+    blocks: List[OutputBlock] = []
+
+    for res in results:
+        try:
+            formatted = reformat_code(res.transform())
+        except Exception:
+            logger.exception(
+                "Failed to reformat code block for identifier %s",
+                res.identifier,
+            )
+            if raise_on_error:
+                raise
+            formatted = res.source_code
+
+        blocks.append(
+            OutputBlock(
+                code=formatted,
+                metadata={},  # what might go here?
+                origin=res,
+            )
+        )
+    return blocks
 
 
 def main(
@@ -60,45 +168,97 @@ def main(
     verbose: int = 0,
     debug: bool = False,
     interactive: bool = False,
-    in_place: bool = False,
-    output_format: str = "input",
+    indent: str = "    ",
+    write_to: Optional[AnyPath] = None,
+    overwrite: bool = False,
+    input_format: Optional[str] = None,
+    output_format: Optional[str] = None,
 ):
+    if write_to is not None:
+        write_to = pathlib.Path(write_to)
+
     result_by_filename = parse_main(
-        filename, verbose=verbose, debug=debug, interactive=interactive
+        filename,
+        verbose=verbose,  # deprecated
+        debug=debug,
+        interactive=interactive,
     )
 
-    for filename, results in result_by_filename.items():
-        for res in results:
-            print()
-            item = res.item
-            if item is None:
-                continue
-            user = item.user
+    settings = tf.FormatSettings(
+        indent=indent,
+    )
+    tf.configure_formatting(settings)
 
-            if verbose > 1:
-                res.dump_source()
+    def group_by_user_loader() -> List[Tuple[Any, pathlib.Path, List[ParseResult]]]:
+        """
+        Group all ParseResults by their loader (or "user" defined wrapper.)
 
-            formatted_code = str(res.transform())
-
-            if isinstance(user, SupportsRewrite):
-                # print(user.to_file_contents())
-                user.rewrite_code(res.identifier, formatted_code)
-                # print(user.to_file_contents())
-
-            if isinstance(user, SupportsCustomSave):
-                if in_place:
-                    user.save_to(filename)
+        This grouping ensures that things like POUs (which may contain multiple
+        actions, methods, and properties stored in different parts of a source
+        file) have their rewrite stage happen in two steps: (1) reformat and
+        then rewrite all disjoint parts of the source and (2) write the final
+        results to the user-specified destination.
+        """
+        by_loader_obj = []
+        last_user = object()
+        last_filename = object()
+        current_group = []
+        for _, results in result_by_filename.items():
+            for res in results:
+                if res.item.user is not last_user or res.filename != last_filename:
+                    current_group = [res]
+                    by_loader_obj.append((res.item.user, res.filename, current_group))
+                    last_user = res.item.user
+                    last_filename = res.filename
                 else:
-                    print(formatted_code)
-            elif isinstance(user, SupportsWrite):
-                contents = user.to_file_contents()
-                if in_place:
-                    mode = "wb" if isinstance(contents, bytes) else "wt"
-                    with open(filename, mode) as fp:
-                        fp.write(contents)
-                else:
-                    print(contents.decode())
-            else:
-                print(formatted_code)
+                    current_group.append(res)
+
+        return by_loader_obj
+
+    for user, filename, results in group_by_user_loader():
+        blocks = get_reformatted_code_blocks(results)
+        if not blocks:
+            continue
+
+        # Default to 'output format' if specified
+        # Fall back to writing to the user-provided input format
+        # Finally try to detect the input format to determine the output format
+        output_handler = output.get_handler_by_name(
+           output_format or input_format or filename.suffix
+        )
+        logger.debug(
+            "Chose output handler %s based on %r -> %r -> %r (%s)",
+            output_handler,
+            output_format,
+            input_format,
+            filename.suffix,
+            filename,
+        )
+
+        # Possibilities:
+        # 1. Save to same file in same format (--overwrite)
+        # 2. Save to different file/directory in same format (--write-to)
+        # 3. Save to different file in different format (--output-format, --write-to)
+        # 4. Save to same file in different format (--output-format xyz, --overwrite)
+
+        # For now, we'll only *really* support cases (1) and (2)
+        # Exceptions:
+        # - Allow anything->plain conversion because it's easy.
+
+        try:
+            output_contents = output_handler(user, filename, blocks)
+        except Exception:
+            logger.exception(
+                "Failed to transform output for handler %s",
+                output_format,
+            )
+            sys.exit(1)
+
+        if not write_to and not overwrite:
+            dump_source_to_console(output_contents)
+            continue
+
+        output_filename = determine_output_filename(filename, write_to)
+        write_source_to_file(output_filename, output_contents, overwrite=overwrite)
 
     return result_by_filename

--- a/blark/format.py
+++ b/blark/format.py
@@ -205,10 +205,11 @@ def main(
         current_group = []
         for _, results in result_by_filename.items():
             for res in results:
+                user = res.item.user
                 if res.item.user is not last_user or res.filename != last_filename:
                     current_group = [res]
-                    by_loader_obj.append((res.item.user, res.filename, current_group))
-                    last_user = res.item.user
+                    by_loader_obj.append((user, res.filename, current_group))
+                    last_user = user
                     last_filename = res.filename
                 else:
                     current_group.append(res)

--- a/blark/format.py
+++ b/blark/format.py
@@ -72,18 +72,26 @@ def main(
                 continue
             user = item.user
 
+            print("item is", type(item), "user is", type(user))
             if verbose > 1:
                 res.dump_source()
 
+            formatted_code = str(res.transform())
+
             if isinstance(user, SupportsRewrite):
                 print("rewrite!", type(user))
-                print(user.to_file_contents())
-                user.rewrite_code(str(res.transform()))
-                print(user.to_file_contents())
+                # print(user.to_file_contents())
+                user.rewrite_code(res.identifier, formatted_code)
+                # print(user.to_file_contents())
 
             if isinstance(user, SupportsCustomSave):
+                if verbose > 1:
+                    print(formatted_code)
+
                 print("custom save!", type(user))
             elif isinstance(user, SupportsWrite):
+                if verbose > 1:
+                    print(formatted_code)
                 print("write!", type(user))
             else:
                 print(res.source_code)

--- a/blark/format.py
+++ b/blark/format.py
@@ -84,19 +84,19 @@ def main(
                 # print(user.to_file_contents())
 
             if isinstance(user, SupportsCustomSave):
-                if verbose > 1:
-                    print(formatted_code)
                 if in_place:
                     user.save_to(filename)
-            elif isinstance(user, SupportsWrite):
-                if verbose > 1:
+                else:
                     print(formatted_code)
+            elif isinstance(user, SupportsWrite):
                 if in_place:
                     contents = user.to_file_contents()
                     mode = "wb" if isinstance(contents, bytes) else "wt"
                     with open(filename, mode) as fp:
                         fp.write(contents)
+                else:
+                    print(formatted_code)
             else:
-                print(res.source_code)
+                print(formatted_code)
 
     return result_by_filename

--- a/blark/format.py
+++ b/blark/format.py
@@ -46,12 +46,12 @@ def build_arg_parser(argparser=None):
     #     help="Output file format"
     # )
 
-    # argparser.add_argument(
-    #     "--in-place",
-    #     action="store_true",
-    #     help="Write formatted contents back to the file"
-    # )
-    #
+    argparser.add_argument(
+        "--in-place",
+        action="store_true",
+        help="Write formatted contents back to the file"
+    )
+
     return argparser
 
 
@@ -60,6 +60,7 @@ def main(
     verbose: int = 0,
     debug: bool = False,
     interactive: bool = False,
+    in_place: bool = False,
 ):
     result_by_filename = parse_main(
         filename, verbose=verbose, debug=debug, interactive=interactive
@@ -72,14 +73,12 @@ def main(
                 continue
             user = item.user
 
-            print("item is", type(item), "user is", type(user))
             if verbose > 1:
                 res.dump_source()
 
             formatted_code = str(res.transform())
 
             if isinstance(user, SupportsRewrite):
-                print("rewrite!", type(user))
                 # print(user.to_file_contents())
                 user.rewrite_code(res.identifier, formatted_code)
                 # print(user.to_file_contents())
@@ -87,12 +86,16 @@ def main(
             if isinstance(user, SupportsCustomSave):
                 if verbose > 1:
                     print(formatted_code)
-
-                print("custom save!", type(user))
+                if in_place:
+                    user.save_to(filename)
             elif isinstance(user, SupportsWrite):
                 if verbose > 1:
                     print(formatted_code)
-                print("write!", type(user))
+                if in_place:
+                    contents = user.to_file_contents()
+                    mode = "wb" if isinstance(contents, bytes) else "wt"
+                    with open(filename, mode) as fp:
+                        fp.write(contents)
             else:
                 print(res.source_code)
 

--- a/blark/iec.lark
+++ b/blark/iec.lark
@@ -1,7 +1,7 @@
 // Beckhoff-flavor IEC61131-3 Lark grammar
+// Part of the blark project by Ken Lauer (@klauer) and contributors.
 //
-// Based on X-Pie Software GmbH's iec2xml grammar (v1.2) which was distributed
-// under the GPL.  Heavily modified and customized for blark.
+// For full license information, see the packaged LICENSE file.
 
 ?start: iec_source
 

--- a/blark/input.py
+++ b/blark/input.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+import dataclasses
+import pathlib
+from typing import Optional, Union
+
+from . import util
+from .typing import BlarkLineToFileLine
+from .util import SourceType
+
+
+@dataclasses.dataclass
+class BlarkSourceItem:
+    file: Optional[pathlib.Path]
+    line: int
+    type: SourceType
+    code: str
+    implicit_end: Optional[str]
+    grammar_rule: Optional[str]
+
+    def get_files(self) -> set[pathlib.Path]:
+        if self.file is not None:
+            return {self.file}
+        return set()
+
+    def get_code(
+        self,
+        include_end: bool = False,
+        blark_lineno: int = 1,
+    ) -> tuple[str, BlarkLineToFileLine]:
+        if include_end and self.implicit_end:
+            code = "\n".join((self.code, self.implicit_end))
+        else:
+            code = self.code
+
+        code = code.rstrip()
+        line_map = util._build_source_to_file_line_map(
+            file_lineno=self.line,
+            blark_lineno=blark_lineno,
+            source=code,
+        )
+        return code, line_map
+
+
+@dataclasses.dataclass
+class BlarkCompositeSourceItem:
+    type: SourceType
+    parts: list[Union[BlarkSourceItem, BlarkCompositeSourceItem]]
+    implicit_end: Optional[str]
+    grammar_rule: Optional[str]
+
+    def get_files(self) -> set[pathlib.Path]:
+        files = set()
+        for part in self.parts:
+            files |= part.get_files()
+        return files
+
+    def get_code(
+        self,
+        include_end: bool = False,
+        blark_lineno: int = 1,
+    ) -> tuple[str, BlarkLineToFileLine]:
+        line_to_file_line = {}
+        result = []
+        for part in self.parts:
+            code, inner_line_map = part.get_code(
+                include_end=False,
+                blark_lineno=blark_lineno,
+            )
+            if code:
+                result.append(code)
+                line_to_file_line.update(inner_line_map)
+                blark_lineno = max(line_to_file_line) + 1
+            # if part.implicit_end:
+            #     result.append(part.implicit_end)
+        if self.implicit_end and include_end:
+            result.append(self.implicit_end)
+            # This doesn't exist in the file...
+            line_to_file_line[blark_lineno] = max(line_to_file_line.values())
+
+        return "\n".join(result), line_to_file_line

--- a/blark/input.py
+++ b/blark/input.py
@@ -2,80 +2,98 @@ from __future__ import annotations
 
 import dataclasses
 import pathlib
-from typing import Optional, Union
+from typing import Optional, Type, Union
 
-from . import util
-from .typing import BlarkLineToFileLine
+from .typing import Self
 from .util import SourceType
+
+
+@dataclasses.dataclass(frozen=True)
+class BlarkSourceLine:
+    filename: Optional[pathlib.Path]
+    lineno: int
+    code: str
+
+    @classmethod
+    def from_code(
+        cls: Type[Self],
+        code: str,
+        first_lineno: int = 1,
+        filename: Optional[pathlib.Path] = None,
+    ) -> list[Self]:
+        return [
+            BlarkSourceLine(
+                code=line,
+                lineno=lineno,
+                filename=filename,
+            )
+            for lineno, line in enumerate(code.splitlines(), start=first_lineno)
+        ]
 
 
 @dataclasses.dataclass
 class BlarkSourceItem:
-    file: Optional[pathlib.Path]
-    line: int
+    identifier: str
+    lines: list[BlarkSourceLine]
     type: SourceType
-    code: str
-    implicit_end: Optional[str]
     grammar_rule: Optional[str]
+    implicit_end: Optional[str]
 
-    def get_files(self) -> set[pathlib.Path]:
-        if self.file is not None:
-            return {self.file}
-        return set()
+    def get_filenames(self) -> set[pathlib.Path]:
+        return {line.filename for line in self.lines if line.filename is not None}
 
-    def get_code(
+    def get_code_and_line_map(
         self,
-        include_end: bool = False,
+        include_end: bool = True,
         blark_lineno: int = 1,
-    ) -> tuple[str, BlarkLineToFileLine]:
-        if include_end and self.implicit_end:
-            code = "\n".join((self.code, self.implicit_end))
-        else:
-            code = self.code
-
-        code = code.rstrip()
-        line_map = util._build_source_to_file_line_map(
-            file_lineno=self.line,
-            blark_lineno=blark_lineno,
-            source=code,
-        )
+    ) -> tuple[str, dict[int, int]]:
+        code = "\n".join(line.code for line in self.lines)
+        line_map = {
+            blark_line: line.lineno
+            for blark_line, line in enumerate(self.lines, start=blark_lineno)
+        }
+        if self.implicit_end and include_end:
+            line_map[max(line_map) + 1] = max(line_map.values())
+            code = "\n".join((code, self.implicit_end))
         return code, line_map
 
 
 @dataclasses.dataclass
 class BlarkCompositeSourceItem:
-    type: SourceType
+    identifier: str
+    filename: pathlib.Path  # primary filename?
     parts: list[Union[BlarkSourceItem, BlarkCompositeSourceItem]]
-    implicit_end: Optional[str]
-    grammar_rule: Optional[str]
 
-    def get_files(self) -> set[pathlib.Path]:
-        files = set()
+    @property
+    def lines(self) -> list[BlarkSourceLine]:
+        lines = []
         for part in self.parts:
-            files |= part.get_files()
-        return files
+            lines.extend(part.lines)
+        return lines
 
-    def get_code(
+    def get_code_and_line_map(
         self,
-        include_end: bool = False,
+        include_end: bool = True,
         blark_lineno: int = 1,
-    ) -> tuple[str, BlarkLineToFileLine]:
+    ) -> tuple[str, dict[int, int]]:
         line_to_file_line = {}
         result = []
         for part in self.parts:
-            code, inner_line_map = part.get_code(
-                include_end=False,
+            code, inner_line_map = part.get_code_and_line_map(
+                include_end=include_end,
                 blark_lineno=blark_lineno,
             )
             if code:
                 result.append(code)
                 line_to_file_line.update(inner_line_map)
                 blark_lineno = max(line_to_file_line) + 1
-            # if part.implicit_end:
-            #     result.append(part.implicit_end)
-        if self.implicit_end and include_end:
-            result.append(self.implicit_end)
-            # This doesn't exist in the file...
-            line_to_file_line[blark_lineno] = max(line_to_file_line.values())
 
         return "\n".join(result), line_to_file_line
+
+    def get_filenames(self) -> set[pathlib.Path]:
+        return {
+            line.filename
+            for part in self.parts
+            for line in part.lines
+            if line.filename is not None
+        }

--- a/blark/input.py
+++ b/blark/input.py
@@ -153,9 +153,30 @@ def load_file_by_name(
     filename: AnyPath,
     input_format: Optional[str] = None,
 ) -> list[Union[BlarkSourceItem, BlarkCompositeSourceItem]]:
+    """
+    Load a file using blark's file input handlers.
+
+    Parameters
+    ----------
+    filename : pathlib.Path or str
+        The filename to load.
+    input_format : str, optional
+        Optionally specify the loader to use, if auto-detection based on
+        filename is insufficient.  This may be either the loader name (e.g.,
+        "plain") or an equivalent filename extension (e.g., ".tcpou")
+
+    Returns
+    -------
+    list[BlarkSourceItem | BlarkCompositeSourceItem]
+        A list of items that were loaded, which may be either singular
+        (`BlarkSourceItem`) or composite (`BlarkCompositeSourceItem`).  An
+        example of a composite file is a Beckhoff TwinCAT TcPOU file, which may
+        contain a declaration, implementation, and a number of
+        properties/methods/actions each with their own grammar rules).
+    """
     filename = pathlib.Path(filename).expanduser().resolve()
     if input_format is not None:
-        extension = input_format
+        extension = input_format.lower()
     else:
         extension = filename.suffix.lower()
     try:

--- a/blark/input.py
+++ b/blark/input.py
@@ -138,8 +138,15 @@ def plain_file_loader(
         contents = fp.read()
 
     source_type, identifier = find_pou_type_and_identifier(contents)
-    if source_type is None:
-        return []
+    # if source_type is None:
+    #     return []
+    source_type = SourceType.general
+    # We'll pick the first identifier here only. IEC source (as what blark
+    # accepts for iput) it's allowed to have multiple declarations in the same
+    # file.
+    # TODO: If people want to use it like this, we could pre-parse the file for
+    # all identifiers and return a BlarkCompositeSourceItem.
+    # As-is, the focus is now on loading TwinCAT XML files directly.
     item = BlarkSourceItem(
         identifier=identifier,
         lines=[
@@ -148,7 +155,7 @@ def plain_file_loader(
         ],
         type=source_type,
         grammar_rule=source_type.get_grammar_rule(),
-        implicit_end=None,  # <-- assume this is already specified
+        implicit_end=source_type.get_implicit_block_end(),
     )
     return [item]
 

--- a/blark/output.py
+++ b/blark/output.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+import dataclasses
+import pathlib
+import typing
+from typing import Any, Callable, Dict, List, Optional, Union
+
+if typing.TYPE_CHECKING:
+    from .parse import ParseResult
+
+
+@dataclasses.dataclass
+class OutputBlock:
+    #: The (optionally modified) code to write as output.
+    code: str
+    #: Metadata to add/modify.
+    metadata: Dict[str, Any] = dataclasses.field(default_factory=dict)
+    #: The origin of the above code block.
+    origin: Optional[ParseResult] = None
+
+
+OutputHandler = Callable[
+    [
+        # The "user" object that parsed the input file.
+        # For now, we're assuming that all output is based on existing
+        # files that were parsed.
+        object,
+        # The input filename, if it exists.
+        Optional[pathlib.Path],
+        # The code the user wants to write to the file.
+        List[OutputBlock]
+    ],
+    # The file contents to be written.
+    Union[str, bytes],
+]
+
+handlers: Dict[str, OutputHandler] = {}
+
+
+def register_output_handler(name: str, handler: OutputHandler):
+    handlers[name.lower()] = handler
+
+
+def get_handler_by_name(name: str) -> OutputHandler:
+    try:
+        return handlers[name.lower()]
+    except KeyError:
+        available = ", ".join(sorted(handlers))
+        raise ValueError(
+            f"Unknown output handler {name!r}. "
+            f"Available handlers include: {available}"
+        ) from None

--- a/blark/parse.py
+++ b/blark/parse.py
@@ -353,6 +353,13 @@ def build_arg_parser(argparser=None):
     )
 
     argparser.add_argument(
+        "--no-meta",
+        action="store_false",
+        dest="include_meta",
+        help="Summarize code inputs and outputs",
+    )
+
+    argparser.add_argument(
         "--filter",
         nargs="*",
         dest="filter_by_name",
@@ -377,6 +384,7 @@ def main(
     print_filename: bool = False,
     print_source: bool = False,
     print_tree: bool = False,
+    include_meta: bool = True,
     filter_by_name: Optional[list[str]] = None,
     input_format: Optional[str] = None,
 ) -> dict[str, list[ParseResult]]:
@@ -458,6 +466,8 @@ def main(
                     exclude_defaults=True,
                     no_copy=True,
                 )
+                if not include_meta:
+                    serialized = util.recursively_remove_keys(serialized, {"meta"})
                 print(json.dumps(serialized, indent=2))
     except KeyboardInterrupt:
         print("\nCaught KeyboardInterrupt; stopping parsing.")

--- a/blark/parse.py
+++ b/blark/parse.py
@@ -228,12 +228,38 @@ def parse_item(
             return
         filename = None
 
-    yield filename, parse_source_code(
+    parsed = parse_source_code(
         code,
         starting_rule=item.grammar_rule,
         line_map=line_map,
         transform=transform,
     )
+
+    if not isinstance(parsed, tf.SourceCode) and transform:
+        print("parsed", parsed)
+        # TODO: remove
+        assert isinstance(
+            parsed,
+            (
+                tf.DataTypeDeclaration,
+                tf.Function,
+                tf.FunctionBlock,
+                tf.Action,
+                tf.Method,
+                tf.Program,
+                tf.Property,
+                # tf.Interface,
+                tf.GlobalVariableDeclarations,
+            ),
+        )
+        parsed = tf.SourceCode(
+            items=[parsed],
+            filename=filename,
+            raw_source=code,
+            line_map=line_map,
+        )
+
+    yield filename, parsed
 
 
 def parse(

--- a/blark/parse.py
+++ b/blark/parse.py
@@ -38,15 +38,15 @@ _PARSER = None
 
 class BlarkStartingRule(enum.Enum):
     iec_source = enum.auto()
+    action = enum.auto()
     data_type_declaration = enum.auto()
-    function_declaration = enum.auto()
-    function_block_type_declaration = enum.auto()
     function_block_method_declaration = enum.auto()
     function_block_property_declaration = enum.auto()
-    program_declaration = enum.auto()
+    function_block_type_declaration = enum.auto()
+    function_declaration = enum.auto()
     global_var_declarations = enum.auto()
+    program_declaration = enum.auto()
     statement_list = enum.auto()
-    action = enum.auto()
 
 
 def new_parser(start: Optional[list[str]] = None, **kwargs) -> lark.Lark:

--- a/blark/parse.py
+++ b/blark/parse.py
@@ -214,7 +214,14 @@ def parse_source_code(
 
     try:
         result.tree = parser.parse(processed_source, start=starting_rule)
-    except Exception as ex:
+    except lark.UnexpectedInput as ex:
+        if line_map:
+            ex.line = line_map.get(ex.line, ex.line)
+        if catch_exceptions:
+            result.exception = ex
+            return result
+        raise
+    except lark.LarkError as ex:
         if catch_exceptions:
             result.exception = ex
             return result

--- a/blark/plain.py
+++ b/blark/plain.py
@@ -1,0 +1,86 @@
+"""Plain (plain text or human-readble flat structured text) file loader."""
+from __future__ import annotations
+
+import dataclasses
+import pathlib
+from typing import Any, List, Optional, Union
+
+from .input import (BlarkCompositeSourceItem, BlarkSourceItem,
+                    register_input_handler)
+from .output import OutputBlock, register_output_handler
+from .util import AnyPath, SourceType, find_pou_type_and_identifier
+
+
+@dataclasses.dataclass
+class PlainFileLoader:
+    filename: pathlib.Path
+    raw_source: str
+    source_type: SourceType = SourceType.general
+    identifier: Optional[str] = None
+    formatted_code: Optional[str] = None
+
+    def rewrite_code(self, identifier: str, code: str) -> None:
+        self.formatted_code = code
+
+    def save_to(self, path: AnyPath) -> None:
+        code = self.to_file_contents()
+        with open(path, "wt") as fp:
+            print(code, file=fp)
+
+    def to_file_contents(self) -> str:
+        if self.formatted_code is not None:
+            return self.formatted_code
+        return self.raw_source
+
+    @classmethod
+    def load(
+        cls,
+        filename: pathlib.Path,
+    ) -> List[Union[BlarkSourceItem, BlarkCompositeSourceItem]]:
+        with open(filename, "rt") as fp:
+            contents = fp.read()
+
+        source_type, identifier = find_pou_type_and_identifier(contents)
+        # if source_type is None:
+        #     return []
+        source_type = SourceType.general
+        # We'll pick the first identifier here only. IEC source (as what blark
+        # accepts for iput) it's allowed to have multiple declarations in the same
+        # file.
+        # TODO: If people want to use it like this, we could pre-parse the file for
+        # all identifiers and return a BlarkCompositeSourceItem.
+        # As-is, the focus is now on loading TwinCAT XML files directly.
+        loader = cls(
+            filename=filename,
+            identifier=identifier,
+            source_type=source_type,
+            raw_source=contents,
+        )
+        return [
+            BlarkSourceItem.from_code(
+                code=contents,
+                source_type=source_type,
+                identifier=identifier or "",
+                first_lineno=1,
+                user=loader,
+                filename=filename,
+            )
+        ]
+
+    @staticmethod
+    def save(
+        user: Any,
+        source_filename: Optional[pathlib.Path],
+        parts: List[OutputBlock],
+    ) -> str:
+        return "\n\n".join(part.code for part in parts)
+
+
+def _register():
+    """Register the plain file handlers."""
+    register_input_handler(".txt", PlainFileLoader.load)
+    register_input_handler(".st", PlainFileLoader.load)
+
+    register_output_handler("plain", PlainFileLoader.save)
+    register_output_handler(".st", PlainFileLoader.save)
+    register_output_handler(".txt", PlainFileLoader.save)

--- a/blark/plain.py
+++ b/blark/plain.py
@@ -78,6 +78,7 @@ class PlainFileLoader:
 
 def _register():
     """Register the plain file handlers."""
+    register_input_handler("plain", PlainFileLoader.load)
     register_input_handler(".txt", PlainFileLoader.load)
     register_input_handler(".st", PlainFileLoader.load)
 

--- a/blark/solution.py
+++ b/blark/solution.py
@@ -80,6 +80,8 @@ def parse_xml_file(fn: AnyPath) -> lxml.etree.Element:
 
 def parse_xml_contents(contents: Union[bytes, str]) -> lxml.etree.Element:
     """Parse the given XML contents with lxml.etree."""
+    if isinstance(contents, str):
+        contents = contents.encode("utf-8")
     return lxml.etree.fromstring(contents)
 
 

--- a/blark/solution.py
+++ b/blark/solution.py
@@ -40,8 +40,8 @@ from . import util
 from .input import (BlarkCompositeSourceItem, BlarkSourceItem, BlarkSourceLine,
                     register_input_handler)
 from .output import OutputBlock, register_output_handler
-from .typing import ContainsBlarkCode, Literal, Self
-from .util import AnyPath, SourceType
+from .typing import ContainsBlarkCode, Self
+from .util import AnyPath, Identifier, SourceType
 
 logger = logging.getLogger(__name__)
 
@@ -204,34 +204,6 @@ def get_child_located_text(
         )
     except IndexError:
         return None
-
-
-DeclarationOrImplementation = Literal["declaration", "implementation"]
-
-
-@dataclasses.dataclass
-class Identifier:
-    parts: List[str]
-    decl_impl: Optional[DeclarationOrImplementation]
-
-    def to_string(self) -> str:
-        parts = ".".join(self.parts)
-        if self.decl_impl:
-            return f"{parts}/{self.decl_impl}"
-        return parts
-
-    @classmethod
-    def from_string(cls: type[Self], value: str) -> Self:
-        if "/" in value:
-            identifier, decl_impl = value.split("/")
-            return cls(
-                parts=identifier.split("."),
-                decl_impl=decl_impl,
-            )
-        return cls(
-            parts=value.split("."),
-            decl_impl=None,
-        )
 
 
 @dataclasses.dataclass

--- a/blark/solution.py
+++ b/blark/solution.py
@@ -733,15 +733,17 @@ class TcProperty(TcSourceChild):
             return []
 
         parts = []
-        for identifier, get_set in (("get", self.get), ("set", self.set)):
-            if get_set is None:
+        for get_or_set, obj in (("get", self.get), ("set", self.set)):
+            if obj is None:
                 continue
 
-            for part in get_set.to_blark():
+            for part in obj.to_blark():
+                # The parent will add on the FB name
+                _, decl_or_impl = part.identifier.split("/")
+                prop_name, _ = base_decl.identifier.split("/")
                 parts.append(
                     BlarkSourceItem(
-                        # TODO
-                        identifier=f"{base_decl.identifier}.{identifier}/{part.identifier}",
+                        identifier=f"{prop_name}.{get_or_set}/{decl_or_impl}",
                         type=SourceType.property,
                         lines=base_decl.lines + part.lines,
                         grammar_rule=SourceType.property.get_grammar_rule(),

--- a/blark/solution.py
+++ b/blark/solution.py
@@ -552,6 +552,8 @@ class TcGVL(TcSource):
 
 @dataclasses.dataclass
 class TcIO(TcSource):
+    """TcIO file - for INTERFACE definitions."""
+
     _tag: ClassVar[str] = "Itf"
     file_extension: ClassVar[str] = ".TcIO"
     default_source_type: ClassVar[SourceType] = SourceType.interface

--- a/blark/solution.py
+++ b/blark/solution.py
@@ -666,6 +666,7 @@ class TcMethod(TcSourceChild):
             return []
         res = self.decl.to_blark()
         for item in res:
+            # item.identifier = f"{self.name}/{item.identifier}"
             item.user = self
         return res
 
@@ -733,13 +734,16 @@ class TcProperty(TcSourceChild):
 
         parts = []
         for identifier, get_set in (("get", self.get), ("set", self.set)):
-            if get_set is not None:
-                (blark_input,) = get_set.to_blark()
+            if get_set is None:
+                continue
+
+            for part in get_set.to_blark():
                 parts.append(
                     BlarkSourceItem(
-                        identifier=f"{base_decl.identifier}.{identifier}",
+                        # TODO
+                        identifier=f"{base_decl.identifier}.{identifier}/{part.identifier}",
                         type=SourceType.property,
-                        lines=base_decl.lines + blark_input.lines,
+                        lines=base_decl.lines + part.lines,
                         grammar_rule=SourceType.property.get_grammar_rule(),
                         implicit_end="END_PROPERTY",
                         user=self,

--- a/blark/solution.py
+++ b/blark/solution.py
@@ -201,8 +201,8 @@ class TcDeclImpl:
 
         if not parts:
             return []
-        if len(parts) == 1:
-            return [parts[0]]
+        # if len(parts) == 1:
+        #     return [parts[0]]
 
         return [
             BlarkCompositeSourceItem(
@@ -439,7 +439,6 @@ class TcPOU(TcSource):
     def to_blark(self) -> list[BlarkInputCode]:
         if self.source_type is None:
             raise RuntimeError("No source type set?")
-            # return []
 
         items = []
 

--- a/blark/solution.py
+++ b/blark/solution.py
@@ -1580,7 +1580,7 @@ def make_solution_from_files(filename: AnyPath) -> Solution:
     return Solution.from_projects(root=abs_path.parent, projects=[abs_path])
 
 
-def single_file_loader(
+def twincat_file_loader(
     filename: pathlib.Path,
 ) -> list[Union[BlarkSourceItem, BlarkCompositeSourceItem]]:
     """
@@ -1594,10 +1594,22 @@ def single_file_loader(
     -------
     list[Union[BlarkSourceItem, BlarkCompositeSourceItem]]
     """
+    # TODO: consider checking more than file extension here...
+    suffix = filename.suffix.lower()
+    if suffix == Solution.file_extension:
+        return solution_loader(filename)
+
+    if suffix in {
+        TwincatTsProject.file_extension,
+        TwincatPlcProject.file_extension,
+    }:
+        return project_loader(filename)
+
     source = TcSource.from_filename(filename)
     if source is None:
         logger.warning("No source found in file %s (is this in error?)", filename)
         return []
+
     return source.to_blark()
 
 
@@ -1713,14 +1725,14 @@ def twincat_file_writer(
     return user.to_file_contents()
 
 
-# register_input_handler("twincat", twincat_detect_file_loader)
-register_input_handler(TcPOU.file_extension, single_file_loader)
-register_input_handler(TcGVL.file_extension, single_file_loader)
-register_input_handler(TcIO.file_extension, single_file_loader)
-register_input_handler(TcDUT.file_extension, single_file_loader)
-register_input_handler(Solution.file_extension, solution_loader)
-register_input_handler(TwincatTsProject.file_extension, project_loader)
-register_input_handler(TwincatPlcProject.file_extension, project_loader)
+register_input_handler("twincat", twincat_file_loader)
+register_input_handler(TcPOU.file_extension, twincat_file_loader)
+register_input_handler(TcGVL.file_extension, twincat_file_loader)
+register_input_handler(TcIO.file_extension, twincat_file_loader)
+register_input_handler(TcDUT.file_extension, twincat_file_loader)
+register_input_handler(Solution.file_extension, twincat_file_loader)
+register_input_handler(TwincatTsProject.file_extension, twincat_file_loader)
+register_input_handler(TwincatPlcProject.file_extension, twincat_file_loader)
 
 register_output_handler("twincat", twincat_file_writer)
 register_output_handler(TcPOU.file_extension, twincat_file_writer)

--- a/blark/solution.py
+++ b/blark/solution.py
@@ -940,6 +940,12 @@ class TcProperty(TcSourceChild):
 
 @dataclasses.dataclass
 class TcExtraInfo:
+    """
+    Extra information in the project XML such as Line IDs.
+
+    blark supports getting the metadata from the file but does not dig any
+    deeper.
+    """
     metadata: dict[str, str]
     xml: lxml.etree.Element
     parent: TcSource
@@ -955,6 +961,7 @@ class TcExtraInfo:
 
 @dataclasses.dataclass
 class TcUnknownXml:
+    """A currently unsupported block of XML in the project."""
     xml: lxml.etree.Element
     parent: TcSource
 
@@ -1069,9 +1076,13 @@ class TwincatSourceCodeItem:
 
 @dataclasses.dataclass
 class DependencyVersion:
+    #: Dependency name.
     name: str
+    #: Dependency version.
     version: str
+    #: Dependency vendor/author.
     vendor: str
+    #: Dependency namespace name, used in code.
     namespace: str
 
     @classmethod

--- a/blark/solution.py
+++ b/blark/solution.py
@@ -1,0 +1,773 @@
+from __future__ import annotations
+
+import codecs
+import copy
+import dataclasses
+import functools
+import logging
+import pathlib
+import re
+from collections.abc import Generator
+from typing import Any, ClassVar, Dict, List, Optional, Union
+
+import lxml
+import lxml.etree
+
+from . import util
+from .util import AnyPath, BlarkSourceCodeItem, SourceType
+
+try:
+    from typing import Self
+except ImportError:
+    from typing_extensions import Self
+
+
+logger = logging.getLogger(__name__)
+
+
+_solution_project_regex = re.compile(
+    (
+        r"^Project\("
+        r'"(?P<solution_guid>.*)"'
+        r"\)"
+        r"\s*=\s*"
+        r'"(?P<project_name>.*?)"'
+        r"\s*,\s*"
+        r'"(?P<project_path>.*?)"'
+        r"\s*,\s*"
+        r'"(?P<project_guid>.*?)"'
+        r"\s*$"
+    ),
+    re.MULTILINE,
+)
+
+
+@functools.lru_cache(maxsize=2048)
+def strip_xml_namespace(tag: str) -> str:
+    """Strip off {{namespace}} from: {{namespace}}tag."""
+    return lxml.etree.QName(tag).localname
+
+
+def parse_xml_file(fn: AnyPath) -> lxml.etree.Element:
+    """Parse a given XML file with lxml.etree.parse."""
+    fn = util.fix_case_insensitive_path(fn)
+
+    with open(fn, "rb") as f:
+        tree = lxml.etree.parse(f)
+
+    return tree.getroot()
+
+
+def parse_xml_contents(contents: str) -> lxml.etree.Element:
+    """Parse the given XML contents with lxml.etree."""
+    return lxml.etree.fromstring(contents)
+
+
+def projects_from_solution_source(
+    solution_source: str,
+    root: pathlib.Path,
+) -> Generator[Project, None, None]:
+    """
+    Find project filenames from the contents of a solution.
+
+    Parameters
+    ----------
+    solution_source : str
+        The solution (.sln) file source.
+    """
+    for match in _solution_project_regex.finditer(solution_source):
+        group = match.groupdict()
+        path = pathlib.PureWindowsPath(group["project_path"])
+        try:
+            local_path = util.fix_case_insensitive_path(root / path)
+        except FileNotFoundError:
+            local_path = None
+            logger.debug(
+                "Unable to find local file while loading projects from solution: %s",
+                path,
+            )
+
+        yield Project(
+            name=group["project_name"],
+            saved_path=path,
+            local_path=local_path,
+            guid=group["project_guid"],
+            solution_guid=group["solution_guid"],
+        )
+
+
+class SourceCodeFile:
+    guid: str
+    path: pathlib.Path
+
+
+def filename_from_xml(xml: Optional[lxml.etree.Element]) -> Optional[pathlib.Path]:
+    if xml is None:
+        return None
+
+    if hasattr(xml, "getroot"):  # TODO -> switch to isinstance
+        root = xml.getroot()
+    elif hasattr(xml, "getroottree"):
+        root = xml.getroottree()
+    else:
+        raise ValueError(f"Unexpected type: {type(xml)}")
+
+    if root.docinfo.URL is None:
+        return None
+    return pathlib.Path(root.docinfo.URL)
+
+
+def get_child_text(
+    xml: lxml.etree.Element,
+    tag: str,
+    namespace: Optional[str] = None,
+    namespaces: Optional[Dict[str, str]] = None,
+    default: Optional[str] = None,
+) -> Optional[str]:
+    namespace = f"{namespace}:" if namespace else ""
+    elements = xml.xpath(f"{namespace}{tag}", namespaces=namespaces)
+    try:
+        return elements[0].text
+    except IndexError:
+        return default
+
+
+def get_child_located_text(
+    xml: lxml.etree.Element,
+    tag: str,
+    namespace: Optional[str] = None,
+    namespaces: Optional[Dict[str, str]] = None,
+) -> Optional[LocatedString]:
+    namespace = f"{namespace}:" if namespace else ""
+    elements = xml.xpath(f"{namespace}{tag}", namespaces=namespaces)
+    try:
+        return LocatedString(
+            line=elements[0].sourceline,
+            value=elements[0].text,
+        )
+    except IndexError:
+        return None
+
+
+@dataclasses.dataclass
+class LocatedString:
+    line: int
+    value: str
+    column: int = 0
+
+
+@dataclasses.dataclass
+class TcDeclImpl:
+    declaration: Optional[LocatedString]
+    implementation: Optional[LocatedString]
+    metadata: Optional[Dict[str, Any]] = None
+
+    def _serialize(self, parent: lxml.etree.Element) -> None:
+        if self.declaration is not None:
+            decl = lxml.etree.Element("Declaration")
+            decl.text = lxml.etree.CDATA(self.declaration.value)
+            parent.append(decl)
+
+        if self.implementation is not None:
+            impl = lxml.etree.Element("Implementation")
+            st = lxml.etree.Element("ST")
+            st.text = lxml.etree.CDATA(self.implementation.value)
+            impl.append(st)
+            parent.append(impl)
+
+    @classmethod
+    def from_xml(
+        cls: type[Self],
+        xml: lxml.etree.Element,
+    ) -> Self:
+        return cls(
+            declaration=get_child_located_text(xml, "Declaration"),
+            # TODO: ST only supported for now
+            implementation=get_child_located_text(xml, "Implementation/ST"),
+            metadata=xml.attrib,
+        )
+
+
+@dataclasses.dataclass
+class TcSource:
+    _tag: ClassVar[str] = ""  # TODO: set in subclass
+    name: str
+    guid: str
+    decl: TcDeclImpl
+    metadata: Dict[str, str]
+    filename: Optional[pathlib.Path]
+
+    def to_xml(self) -> lxml.etree.Element:
+        md = dict(self.metadata)
+        plc_obj = lxml.etree.Element("TcPlcObject")
+        plc_obj.attrib["Version"] = md.pop("version", "")
+        plc_obj.attrib["ProductVersion"] = md.pop("product_version", "")
+        primary = lxml.etree.Element(self._tag)
+        plc_obj.append(primary)
+        self._serialize(primary)
+        primary.attrib.update(md)
+        return plc_obj
+
+    def _serialize(self, primary: lxml.etree.Element):
+        primary.attrib["Name"] = self.name
+        primary.attrib["Id"] = self.guid
+        if self.decl is not None:
+            self.decl._serialize(primary)
+
+    @classmethod
+    def from_xml(
+        cls: type[Self],
+        xml: lxml.etree.Element,
+        filename: Optional[pathlib.Path] = None,
+    ) -> Optional[Union[TcDUT, TcTTO, TcPOU, TcIO, TcGVL]]:
+        try:
+            tcplc_object = xml.xpath("/TcPlcObject")[0]
+        except IndexError:
+            return None
+
+        cls_to_xpath = {
+            TcDUT: TcDUT._tag,
+            TcGVL: TcGVL._tag,
+            TcPOU: TcPOU._tag,
+            TcIO: TcIO._tag,
+            TcTTO: TcTTO._tag,
+        }
+
+        for cls, xpath in cls_to_xpath.items():
+            items = tcplc_object.xpath(xpath)
+            if items:
+                item = items[0]
+                break
+        else:
+            return None
+
+        metadata = dict(item.attrib)
+        metadata["version"] = tcplc_object.attrib.get("Version", "")
+        metadata["product_version"] = tcplc_object.attrib.get("ProductVersion", "")
+        kwargs = cls._get_additional_args_from_xml(item)
+        return cls(
+            filename=filename or filename_from_xml(xml),
+            name=metadata.pop("Name", ""),
+            guid=metadata.pop("Id", ""),
+            decl=TcDeclImpl.from_xml(item),
+            metadata=metadata,
+            **kwargs,
+        )
+
+    @classmethod
+    def _get_additional_args_from_xml(
+        cls,
+        xml: lxml.etree.Element,  # noqa
+    ) -> Dict[str, Any]:
+        return {}
+
+    @classmethod
+    def from_contents(
+        cls: type[Self],
+        contents: str,
+        filename: Optional[pathlib.Path] = None,
+    ) -> Optional[Union[TcDUT, TcPOU, TcIO, TcTTO, TcGVL]]:
+        return cls.from_xml(parse_xml_contents(contents), filename=filename)
+
+    @classmethod
+    def from_filename(
+        cls: type[Self],
+        filename: AnyPath,
+    ) -> Optional[Union[TcDUT, TcPOU, TcIO, TcTTO, TcGVL]]:
+        with open(filename) as fp:
+            raw_contents = fp.read()
+        return cls.from_contents(raw_contents, filename=pathlib.Path(filename))
+
+
+@dataclasses.dataclass
+class TcDUT(TcSource):
+    _tag: ClassVar[str] = "DUT"
+    source_type: ClassVar[SourceType] = SourceType.struct
+
+
+@dataclasses.dataclass
+class TcGVL(TcSource):
+    _tag: ClassVar[str] = "GVL"
+    source_type: ClassVar[SourceType] = SourceType.var_global
+
+
+@dataclasses.dataclass
+class TcIO(TcSource):
+    _tag: ClassVar[str] = "Itf"
+    parts: List[Union[TcMethod, TcProperty, TcUnknownXml]]
+
+    def _serialize(self, primary: lxml.etree.Element) -> None:
+        super()._serialize(primary)
+        for part in self.parts:
+            if isinstance(part, (TcUnknownXml, TcExtraInfo)):
+                primary.append(copy.deepcopy(part.xml))
+            else:
+                part_tag = lxml.etree.Element(part._tag)
+                part._serialize(part_tag)
+                primary.append(part_tag)
+
+    @classmethod
+    def _handle_child(
+        cls, child: lxml.etree.Element
+    ) -> Optional[Union[TcAction, TcMethod, TcProperty, TcExtraInfo, TcUnknownXml]]:
+        if child.tag in ("Declaration", "Implementation"):
+            # Already handled
+            return None
+        if child.tag == "Action":
+            return TcAction.from_xml(child)
+        if child.tag == "Method":
+            return TcMethod.from_xml(child)
+        if child.tag == "Property":
+            return TcProperty.from_xml(child)
+        if child.tag in ("Folder", "LineIds"):
+            return TcExtraInfo.from_xml(child)
+        return TcUnknownXml(child)
+
+    @classmethod
+    def _get_additional_args_from_xml(cls, xml: lxml.etree.Element) -> Dict[str, Any]:
+        # Only support ST for now:
+        parts = [cls._handle_child(child) for child in xml.iterchildren()]
+        return {
+            "parts": [part for part in parts if part is not None],
+        }
+
+
+@dataclasses.dataclass
+class TcTTO(TcSource):
+    _tag: ClassVar[str] = "Task"
+    xml: lxml.etree.Element
+
+    def _serialize(self, primary: lxml.etree.Element) -> None:
+        primary.getparent().replace(primary, self.xml)
+
+    @classmethod
+    def _get_additional_args_from_xml(cls, xml: lxml.etree.Element) -> Dict[str, Any]:
+        return {"xml": xml}
+
+
+@dataclasses.dataclass
+class TcPOU(TcSource):
+    _tag: ClassVar[str] = "POU"
+    parts: List[Union[TcAction, TcMethod, TcProperty, TcUnknownXml]]
+    source_type: Optional[SourceType]
+
+    def to_blark(self) -> List[BlarkSourceCodeItem]:
+        if self.source_type is None:
+            return []
+
+        items = []
+
+        if self.decl is not None:
+            if self.decl.declaration is not None:
+                items.append(
+                    BlarkSourceCodeItem(
+                        file=self.filename,
+                        type=self.source_type,
+                        implicit_end=self.source_type.get_implicit_block_end(),
+                        grammar_rule=self.source_type.get_grammar_rule(),
+                        code=self.decl.declaration.value,
+                        line=self.decl.declaration.line,
+                    )
+                )
+            if self.decl.implementation is not None and self.decl.implementation.value.strip():
+                # TODO - not ideal - empty statement list throws error
+                if util.remove_all_comments(self.decl.implementation.value).strip():
+                    items.append(
+                        BlarkSourceCodeItem(
+                            file=self.filename,
+                            type=self.source_type,
+                            implicit_end=None,
+                            grammar_rule="statement_list",
+                            code=self.decl.implementation.value,
+                            line=self.decl.implementation.line,
+                        )
+                    )
+        return items
+
+    def _serialize(self, primary: lxml.etree.Element) -> None:
+        super()._serialize(primary)
+        for part in self.parts:
+            if isinstance(part, (TcUnknownXml, TcExtraInfo)):
+                primary.append(copy.deepcopy(part.xml))
+            else:
+                part_tag = lxml.etree.Element(part._tag)
+                part._serialize(part_tag)
+                primary.append(part_tag)
+
+    @classmethod
+    def _handle_child(
+        cls, child: lxml.etree.Element
+    ) -> Optional[Union[TcAction, TcMethod, TcProperty, TcExtraInfo, TcUnknownXml]]:
+        if child.tag in ("Declaration", "Implementation"):
+            # Already handled
+            return None
+        if child.tag == "Action":
+            return TcAction.from_xml(child)
+        if child.tag == "Method":
+            return TcMethod.from_xml(child)
+        if child.tag == "Property":
+            return TcProperty.from_xml(child)
+        if child.tag in ("Folder", "LineIds"):
+            return TcExtraInfo.from_xml(child)
+        return TcUnknownXml(child)
+
+    @classmethod
+    def _get_additional_args_from_xml(cls, xml: lxml.etree.Element) -> Dict[str, Any]:
+        # Only support ST for now:
+        decl = TcDeclImpl.from_xml(xml)
+        if decl and decl.declaration:
+            source_type = util.find_pou_type(decl.declaration.value)
+        else:
+            source_type = None
+
+        parts = [cls._handle_child(child) for child in xml.iterchildren()]
+        return {
+            "parts": [part for part in parts if part is not None],
+            "source_type": source_type,
+        }
+
+
+@dataclasses.dataclass
+class TcSourceChild(TcSource):
+    def _serialize(self, parent: lxml.etree.Element) -> None:
+        super()._serialize(parent)
+        parent.attrib.update(self.metadata or {})
+
+    @classmethod
+    def from_xml(
+        cls: type[Self],
+        xml: lxml.etree.Element,
+        filename: Optional[pathlib.Path] = None,
+    ) -> Self:
+        metadata = dict(xml.attrib)
+        kwargs = cls._get_additional_args_from_xml(xml)
+        return cls(
+            filename=filename or filename_from_xml(xml),
+            name=metadata.pop("Name", ""),
+            guid=metadata.pop("Id", ""),
+            decl=TcDeclImpl.from_xml(xml),
+            metadata=metadata,
+            **kwargs,
+        )
+
+
+@dataclasses.dataclass
+class TcMethod(TcSourceChild):
+    _tag: ClassVar[str] = "Method"
+
+
+@dataclasses.dataclass
+class TcAction(TcSourceChild):
+    _tag: ClassVar[str] = "Action"
+
+
+@dataclasses.dataclass
+class TcProperty(TcSourceChild):
+    _tag: ClassVar[str] = "Property"
+
+    get: Optional[TcDeclImpl]
+    set: Optional[TcDeclImpl]
+
+    def _serialize(self, parent: lxml.etree.Element) -> None:
+        super()._serialize(parent)
+        if self.get is not None:
+            get = lxml.etree.Element("Get")
+            parent.append(get)
+            self.get._serialize(get)
+            get.attrib.update(self.get.metadata or {})
+
+        if self.set is not None:
+            set = lxml.etree.Element("Set")
+            parent.append(set)
+            self.set._serialize(set)
+            set.attrib.update(self.set.metadata or {})
+
+    @classmethod
+    def _get_additional_args_from_xml(cls, xml: lxml.etree.Element) -> Dict[str, Any]:
+        try:
+            get_section = xml.xpath("Get")[0]
+        except IndexError:
+            get = None
+        else:
+            get = TcDeclImpl.from_xml(get_section)
+
+        try:
+            set_section = xml.xpath("Set")[0]
+        except IndexError:
+            set = None
+        else:
+            set = TcDeclImpl.from_xml(set_section)
+        return dict(get=get, set=set)
+
+
+@dataclasses.dataclass
+class TcExtraInfo:
+    metadata: Dict[str, str]
+    xml: lxml.etree.Element
+
+    @classmethod
+    def from_xml(
+        cls: type[Self],
+        xml: lxml.etree.Element,
+    ) -> Self:
+        return cls(metadata=xml.attrib, xml=xml)
+
+
+@dataclasses.dataclass
+class TcUnknownXml:
+    xml: lxml.etree.Element
+
+
+@dataclasses.dataclass
+class TwincatSourceCodeItem:
+    saved_path: pathlib.PureWindowsPath
+    local_path: Optional[pathlib.Path]
+    subtype: Optional[str]
+    link_always: bool
+    guid: Optional[str] = None
+    raw_contents: Optional[str] = None
+    contents: Optional[Union[TcDUT, TcPOU, TcIO, TcGVL, TcTTO]] = None
+
+    def to_string(self, delimiter: str = "\r\n") -> str:
+        if self.contents is None:
+            raise ValueError(
+                f"No contents to save (file not found on host for {self.saved_path})"
+            )
+
+        lines = ['<?xml version="1.0" encoding="utf-8"?>']
+        tree = self.contents.to_xml()
+        lxml.etree.indent(tree, space=" " * 2)
+        lines += lxml.etree.tostring(
+            tree,
+            pretty_print=True,
+            encoding="utf-8",
+        ).decode("utf-8").splitlines()
+        return delimiter.join(lines)
+
+    def save_to(self, path: AnyPath, delimiter: str = "\r\n") -> None:
+        code = self.to_string(delimiter)
+        with codecs.open(str(path), "w", "utf-8-sig") as fp:
+            fp.write(code)
+
+    @classmethod
+    def from_compile_xml(
+        cls: type[Self],
+        xml: lxml.etree.Element,
+    ) -> Optional[Self]:
+        saved_path = pathlib.PureWindowsPath(xml.attrib["Include"])
+        try:
+            plcproj_filename = filename_from_xml(xml)
+            if plcproj_filename is None:
+                raise FileNotFoundError("No project filename?")
+            local_path = util.fix_case_insensitive_path(plcproj_filename.parent / saved_path)
+        except FileNotFoundError:
+            local_path = None
+            raw_contents = None
+            contents = None
+            logger.debug(
+                "Unable to find local file while loading projects from solution: %s",
+                saved_path,
+                exc_info=True,
+            )
+        else:
+            with open(local_path) as fp:
+                raw_contents = fp.read()
+            contents = TcSource.from_contents(raw_contents, filename=local_path)
+
+        namespaces = {"msbuild": xml.xpath("namespace-uri()")}
+        subtype = get_child_text(
+            xml,
+            "SubType",
+            namespace="msbuild",
+            namespaces=namespaces,
+            default="",
+        )
+        link_always = (
+            get_child_text(
+                xml,
+                "LinkAlways",
+                namespace="msbuild",
+                namespaces=namespaces,
+                default="false",
+            )
+            == "true"
+        )
+
+        return cls(
+            contents=contents,
+            guid=None,
+            link_always=link_always,
+            local_path=local_path,
+            raw_contents=raw_contents,
+            saved_path=saved_path,
+            subtype=subtype,
+        )
+
+
+@dataclasses.dataclass
+class TwincatPlcProject:
+    guid: str
+    xti_path: Optional[pathlib.Path]
+    plcproj_path: Optional[pathlib.Path]
+    properties: Dict[str, str]
+    sources: List[TwincatSourceCodeItem]
+
+    @classmethod
+    def from_standalone_xml(
+        cls: type[Self],
+        xti_xml: Optional[lxml.etree.Element],
+        plcproj_xml: lxml.etree.Element,
+    ) -> Self:
+        namespaces = {"msbuild": plcproj_xml.xpath("namespace-uri()")}
+        properties = {
+            strip_xml_namespace(element.tag): element.text
+            for element in plcproj_xml.xpath(
+                "/msbuild:Project/msbuild:PropertyGroup/msbuild:*",
+                namespaces=namespaces,
+            )
+        }
+        sources = [
+            TwincatSourceCodeItem.from_compile_xml(xml)
+            for xml in plcproj_xml.xpath(
+                "/msbuild:Project/msbuild:ItemGroup/msbuild:Compile",
+                namespaces=namespaces,
+            )
+        ]
+        return cls(
+            guid=properties.get("ProjectGuid", ""),
+            xti_path=filename_from_xml(xti_xml),
+            plcproj_path=filename_from_xml(plcproj_xml),
+            sources=[source for source in sources if source is not None],
+            properties=properties,
+        )
+
+    @classmethod
+    def from_xti_filename(cls: type[Self], xti_filename: pathlib.Path) -> Self:
+        xti = parse_xml_file(xti_filename)
+        (project,) = xti.xpath("/TcSmItem/Project")
+        prj_file_path = pathlib.PureWindowsPath(project.attrib.get("PrjFilePath"))
+
+        plcproj_path = util.fix_case_insensitive_path(xti_filename.parent / prj_file_path)
+        plcproj = parse_xml_file(plcproj_path)
+        return cls.from_standalone_xml(xti, plcproj)
+
+    @classmethod
+    def from_project_xml(
+        cls: type[Self],
+        plc_project: lxml.etree.Element,
+        root: pathlib.Path,
+    ) -> Self:
+        # tsproj -> xti -> plcproj
+        file = plc_project.attrib.get("File", None)
+        if file is None:
+            # return cls.from_standalone_xml(plc_project, None)
+            raise NotImplementedError
+
+        plc_filename = pathlib.Path(file)
+        xti_filename = root / "_Config" / "PLC" / plc_filename
+        return cls.from_xti_filename(xti_filename=xti_filename)
+
+    # @classmethod
+    # def from_filename(cls: type[Self], filename: pathlib.Path) -> Self:
+    #     return cls.from_standalone_xml(parse_xml_file(filename), filename.parent)
+
+
+def get_project_guid(element: lxml.etree.Element) -> str:
+    try:
+        proj = element.xpath("/TcSmProject/Project")[0]
+    except IndexError:
+        return ""
+
+    return proj.attrib.get("ProjectGUID", "")
+
+
+def get_project_target_netid(element: lxml.etree.Element) -> str:
+    try:
+        proj = element.xpath("/TcSmProject/Project")[0]
+    except IndexError:
+        return ""
+
+    return proj.attrib.get("TargetNetId", "")
+
+
+@dataclasses.dataclass
+class TwincatTsProject:
+    guid: str
+    netid: str
+    path: pathlib.Path
+    plcs: List[TwincatPlcProject]
+
+    @classmethod
+    def from_filename(cls, filename: pathlib.Path) -> TwincatTsProject:
+        tsproj = parse_xml_file(filename)
+        plcs = [
+            TwincatPlcProject.from_project_xml(plc_project, filename.parent)
+            for plc_project in tsproj.xpath("/TcSmProject/Project/Plc/Project")
+        ]
+
+        return TwincatTsProject(
+            path=filename,
+            guid=get_project_guid(tsproj),
+            netid=get_project_target_netid(tsproj),
+            plcs=plcs,
+        )
+
+
+@dataclasses.dataclass
+class Project:
+    name: str
+    saved_path: pathlib.PureWindowsPath
+    local_path: Optional[pathlib.Path]
+    guid: str
+    solution_guid: str
+
+    # def find_source_code(
+    #     self, root: pathlib.Path
+    # ) -> Generator[SourceCodeFile, None, None]:
+    #     ...
+    #
+    def load(self):
+        if self.local_path is None:
+            raise FileNotFoundError(
+                f"File from project settings not found: {self.saved_path}"
+            )
+
+        if self.local_path.suffix.lower() in (".tsproj",):
+            return TwincatTsProject.from_filename(self.local_path)
+
+        raise NotImplementedError(f"Format not yet supported: {self.local_path.suffix}")
+
+
+@dataclasses.dataclass
+class Solution:
+    root: pathlib.Path
+    projects: List[Project]
+    filename: Optional[pathlib.Path] = None
+
+    @property
+    def projects_by_name(self) -> Dict[str, Project]:
+        return {project.name: project for project in self.projects}
+
+    @classmethod
+    def from_contents(
+        cls: type[Self],
+        solution_source: str,
+        root: pathlib.Path,
+        filename: Optional[pathlib.Path] = None,
+    ) -> Self:
+        return cls(
+            root=root,
+            filename=filename,
+            projects=list(projects_from_solution_source(solution_source, root=root)),
+        )
+
+    @classmethod
+    def from_filename(cls: type[Self], filename: AnyPath) -> Self:
+        filename = pathlib.Path(filename).expanduser().resolve()
+        with open(filename, "rt") as f:
+            solution_source = f.read()
+        return cls.from_contents(
+            solution_source=solution_source,
+            root=filename.parent,
+            filename=filename,
+        )

--- a/blark/solution.py
+++ b/blark/solution.py
@@ -669,6 +669,10 @@ class TcMethod(TcSourceChild):
 class TcAction(TcSourceChild):
     _tag: ClassVar[str] = "Action"
 
+    def rewrite_code(self, identifier: str, contents: str):
+        # TODO: need to not save the implicit end line
+        self.decl.implementation.value = contents
+
     def to_blark(self) -> list[Union[BlarkCompositeSourceItem, BlarkSourceItem]]:
         if self.decl is None or self.decl.implementation is None:
             return []
@@ -708,6 +712,10 @@ class TcProperty(TcSourceChild):
 
     get: Optional[TcDeclImpl]
     set: Optional[TcDeclImpl]
+
+    def rewrite_code(self, identifier: str, contents: str):
+        # TODO: need to not save the implicit end line
+        raise NotImplementedError()
 
     def to_blark(self) -> list[Union[BlarkCompositeSourceItem, BlarkSourceItem]]:
         # NOTE: ignoring super().to_blark()

--- a/blark/summary.py
+++ b/blark/summary.py
@@ -650,7 +650,7 @@ class ProgramSummary(Summary):
 
 
 def path_to_file_and_line(path: List[Summary]) -> List[Tuple[pathlib.Path, int]]:
-    """Get symbol metadata given a pytmc Symbol."""
+    """Get the file/line number context for the summary items."""
     return [(part.filename, part.item.meta.line) for part in path]
 
 

--- a/blark/summary.py
+++ b/blark/summary.py
@@ -791,13 +791,13 @@ class CodeSummary:
         code: tf.SourceCode, filename: Optional[pathlib.Path] = None
     ) -> CodeSummary:
         result = CodeSummary()
-        code_by_lines = [""] + code.raw_source.splitlines()
         items = code.items
 
         def get_code_by_meta(meta: Optional[tf.Meta]) -> str:
-            if not meta:
+            if meta is None or meta.line is None or meta.end_line is None:
                 return ""
-            return "\n".join(code_by_lines[meta.line:meta.end_line + 1])
+
+            return "\n".join(code.range_from_file_lines(meta.line, meta.end_line))
 
         last_parent = None
         for item in items:

--- a/blark/tests/conftest.py
+++ b/blark/tests/conftest.py
@@ -6,6 +6,7 @@ import pathlib
 
 import pytest
 
+from ..dependency_store import DependencyStore
 from ..parse import new_parser
 
 TEST_PATH = pathlib.Path(__file__).parent
@@ -17,6 +18,10 @@ except ImportError:
     apischema = None
 
 APISCHEMA_SKIP = apischema is None
+# Dependency store:
+DS_CONFIG_ROOT = TEST_PATH / "twincat_root"
+DS_CONFIG = DS_CONFIG_ROOT / "config.json"
+
 
 twincat_pou_filenames = list(str(path) for path in TEST_PATH.glob("**/*.TcPOU"))
 additional_pous = TEST_PATH / "additional_pous.txt"
@@ -100,3 +105,8 @@ def source_filename(request):
     if not os.path.exists(request.param):
         pytest.skip(f"File missing: {request.param}")
     return request.param
+
+
+@pytest.fixture(scope="function")
+def store() -> DependencyStore:
+    return DependencyStore(root=DS_CONFIG_ROOT)

--- a/blark/tests/test_cli.py
+++ b/blark/tests/test_cli.py
@@ -16,9 +16,7 @@ from ..parse import main as parse_main
 from . import conftest
 
 # Pick a subset of the test files to run with the CLI tools:
-parse_filenames = (
-    conftest.twincat_pou_filenames[:5] + conftest.structured_text_filenames[:5]
-)
+parse_filenames = conftest.twincat_pou_filenames + conftest.structured_text_filenames
 
 README_PATH = MODULE_PATH.parent / "README.md"
 
@@ -51,7 +49,12 @@ def input_filename(request):
 @pytest.fixture
 def skip_summary(input_filename: str) -> bool:
     return pathlib.Path(input_filename).name in {
+        "and_then_or_else.st",
+        # "array_initializer.st",
+        "array_of_arrays.st",
         "array_of_objects.st",
+        "array_with_integer_initializer.st",
+        "dereference_method.st",
         "stray_comment.st",
     }
 

--- a/blark/tests/test_cli.py
+++ b/blark/tests/test_cli.py
@@ -59,7 +59,7 @@ def input_filename(request):
             id="json",
         ),
         param(
-            dict(verbose=3, summary=True, debug=True),
+            dict(verbose=3, output_summary=True, debug=True),
             id="verbose",
         ),
     ]

--- a/blark/tests/test_dependency_store.py
+++ b/blark/tests/test_dependency_store.py
@@ -1,0 +1,38 @@
+from typing import Optional
+
+import pytest
+
+from ..dependency_store import DependencyStore
+from . import conftest
+
+DS_CONFIG_ROOT = conftest.TEST_PATH / "twincat_root"
+DS_CONFIG = DS_CONFIG_ROOT / "config.json"
+
+
+if not DS_CONFIG.exists():
+    pytest.skip(
+        "twincat_root directory not found! Did you recursively clone the "
+        "repository? (git clone --recursive ...)"
+    )
+
+
+@pytest.fixture(scope="function")
+def store() -> DependencyStore:
+    return DependencyStore(root=DS_CONFIG_ROOT)
+
+
+@pytest.mark.parametrize(
+    "project_name, version",
+    [
+        ("LCLS_General", "v2.8.1"),
+        ("project_a", "*"),
+        ("project_b", "*"),
+    ]
+)
+def test_load_project(store: DependencyStore, project_name: str, version: Optional[str]):
+    assert project_name in store.config.libraries
+    matches = store.get_dependency(project_name, version)
+    try:
+        match, = matches
+    except ValueError:
+        raise RuntimeError(f"No match for project {project_name} version={version}")

--- a/blark/tests/test_dependency_store.py
+++ b/blark/tests/test_dependency_store.py
@@ -5,20 +5,11 @@ import pytest
 from ..dependency_store import DependencyStore
 from . import conftest
 
-DS_CONFIG_ROOT = conftest.TEST_PATH / "twincat_root"
-DS_CONFIG = DS_CONFIG_ROOT / "config.json"
-
-
-if not DS_CONFIG.exists():
+if not conftest.DS_CONFIG.exists():
     pytest.skip(
         "twincat_root directory not found! Did you recursively clone the "
         "repository? (git clone --recursive ...)"
     )
-
-
-@pytest.fixture(scope="function")
-def store() -> DependencyStore:
-    return DependencyStore(root=DS_CONFIG_ROOT)
 
 
 @pytest.mark.parametrize(
@@ -29,7 +20,11 @@ def store() -> DependencyStore:
         ("project_b", "*"),
     ]
 )
-def test_load_project(store: DependencyStore, project_name: str, version: Optional[str]):
+def test_load_project(
+    store: DependencyStore,
+    project_name: str,
+    version: Optional[str],
+):
     assert project_name in store.config.libraries
     matches = store.get_dependency(project_name, version)
     try:

--- a/blark/tests/test_parsing.py
+++ b/blark/tests/test_parsing.py
@@ -10,15 +10,15 @@ TEST_PATH = pathlib.Path(__file__).parent
 
 def test_parsing_tcpous(twincat_pou_filename: str):
     """Test parsing TwinCAT TcPOU files."""
-    (result,) = list(parse(twincat_pou_filename))
-    transformed = result.transform()
-    print("transformed:")
-    print(transformed)
-    print("summary:")
-    if result.exception:
-        raise result.exception
-    print(summarize(transformed))
-    conftest.check_serialization(transformed, deserialize=False)
+    for part in parse(twincat_pou_filename):
+        transformed = part.transform()
+        print("transformed:")
+        print(transformed)
+        print("summary:")
+        if part.exception:
+            raise part.exception
+        print(summarize(transformed))
+        conftest.check_serialization(transformed, deserialize=False)
 
 
 def test_parsing_source(source_filename: str):

--- a/blark/tests/test_parsing.py
+++ b/blark/tests/test_parsing.py
@@ -10,15 +10,15 @@ TEST_PATH = pathlib.Path(__file__).parent
 
 def test_parsing_tcpous(twincat_pou_filename: str):
     """Test parsing TwinCAT TcPOU files."""
-    ((_, result),) = list(parse(twincat_pou_filename))
+    (result,) = list(parse(twincat_pou_filename))
+    transformed = result.transform()
     print("transformed:")
-    print(result)
+    print(transformed)
     print("summary:")
-    if isinstance(result, Exception):
-        raise result
-    print(summarize(result))
-
-    conftest.check_serialization(result, deserialize=False)
+    if result.exception:
+        raise result.exception
+    print(summarize(transformed))
+    conftest.check_serialization(transformed, deserialize=False)
 
 
 def test_parsing_source(source_filename: str):
@@ -27,13 +27,14 @@ def test_parsing_source(source_filename: str):
         content = src.read()
 
     result = parse_source_code(content)
+    transformed = result.transform()
     print("transformed:")
-    print(result)
+    print(transformed)
     print("summary:")
-    if isinstance(result, Exception):
-        raise result
-    print(summarize(result))
-    conftest.check_serialization(result, deserialize=False)
+    if result.exception:
+        raise result.exception
+    print(summarize(transformed))
+    conftest.check_serialization(transformed, deserialize=False)
 
 
 must_fail = pytest.mark.xfail(reason="Bad input", strict=True)

--- a/blark/tests/test_parsing.py
+++ b/blark/tests/test_parsing.py
@@ -2,6 +2,8 @@ import pathlib
 
 import pytest
 
+from blark.util import SourceType
+
 from ..parse import parse, parse_source_code, summarize
 from . import conftest
 
@@ -10,15 +12,19 @@ TEST_PATH = pathlib.Path(__file__).parent
 
 def test_parsing_tcpous(twincat_pou_filename: str):
     """Test parsing TwinCAT TcPOU files."""
+    all_parts = []
     for part in parse(twincat_pou_filename):
+        all_parts.append(part)
+
         transformed = part.transform()
         print("transformed:")
         print(transformed)
         print("summary:")
         if part.exception:
             raise part.exception
-        print(summarize(transformed))
         conftest.check_serialization(transformed, deserialize=False)
+
+    print(summarize(all_parts))
 
 
 def test_parsing_source(source_filename: str):
@@ -33,7 +39,17 @@ def test_parsing_source(source_filename: str):
     print("summary:")
     if result.exception:
         raise result.exception
-    print(summarize(transformed))
+
+    if result.item.type in (
+        SourceType.dut,
+        SourceType.function,
+        SourceType.function_block,
+        SourceType.interface,
+        SourceType.statement_list,
+        SourceType.var_global,
+        SourceType.program,
+    ):
+        print(summarize([result]))
     conftest.check_serialization(transformed, deserialize=False)
 
 

--- a/blark/tests/test_solution.py
+++ b/blark/tests/test_solution.py
@@ -1,0 +1,21 @@
+import pathlib
+
+from ..solution import Project, Solution
+
+
+def test_solution_regex():
+    solution_source = r"""
+        Project("{AAAAAAAA-BBBB-CCCC-DDDD-EEEEEEEEEEE0}") = "a", "a\a.tsproj", "{AAAAAAAA-BBBB-CCCC-DDDD-EEEEEEEEEEE1}"
+    """.strip()  # noqa: E501
+
+    root = pathlib.Path.cwd().resolve()
+    solution = Solution.from_contents(solution_source, root)
+    assert solution.projects == [
+        Project(
+            name="a",
+            solution_guid="{AAAAAAAA-BBBB-CCCC-DDDD-EEEEEEEEEEE0}",
+            guid="{AAAAAAAA-BBBB-CCCC-DDDD-EEEEEEEEEEE1}",
+            saved_path=pathlib.PureWindowsPath("a") / "a.tsproj",
+            local_path=None,
+        ),
+    ]

--- a/blark/tests/test_summary.py
+++ b/blark/tests/test_summary.py
@@ -150,7 +150,9 @@ def test_twincat_general(twincat_general_281: PlcProjectMetadata):
         ]
     )
     # Ensure comments transferred over
-    impl = str(loghandler.implementation)
+    assert loghandler.implementation is None
+
+    impl = str(loghandler["CircuitBreaker"].implementation)
     assert "Logic explanation" in impl
     assert "// reset the count for the next" in impl
     # Check about reformatting

--- a/blark/tests/test_summary.py
+++ b/blark/tests/test_summary.py
@@ -1,0 +1,241 @@
+from dataclasses import dataclass
+from typing import Optional
+
+import pytest
+
+from .. import transform as tf
+from ..dependency_store import DependencyStore, PlcProjectMetadata
+from ..summary import DeclarationSummary
+
+
+@dataclass
+class DeclarationCheck:
+    name: str
+    base_type: str
+    value: Optional[str] = None
+    location: Optional[str] = None
+    comments: Optional[list[str]] = None
+
+
+def check_declarations(
+    container: dict[str, DeclarationSummary],
+    checks: list[DeclarationCheck]
+):
+    """
+    Check that ``container`` has the listed declarations - and only those.
+
+    Parameters
+    ----------
+    container : dict[str, DeclarationSummary]
+    checks : list[DeclarationCheck]
+    """
+    for check in checks:
+        try:
+            summary = container[check.name]
+        except KeyError:
+            raise KeyError(f"{check.name} not listed in the declaration section")
+
+        assert summary.base_type == check.base_type
+        if check.value is None:
+            assert summary.value == "None"  # TODO?
+            assert summary.item.init.value is None
+        else:
+            assert summary.value == check.value
+            assert str(summary.item.init.value) == check.value
+
+        if check.comments is not None:
+            comments = list(str(comment) for comment in summary.item.meta.comments)
+            assert comments == check.comments
+
+        if check.location is not None:
+            assert summary.location == check.location
+
+    all_decls = {str(decl) for decl in container}
+    expected_decls = {str(decl.name) for decl in checks}
+    assert all_decls == expected_decls
+
+
+@pytest.fixture
+def project_a(store: DependencyStore) -> PlcProjectMetadata:
+    # This is project a from the git submodule included with the blark test
+    # suite
+    proj, = store.get_dependency("project_a")
+    return proj
+
+
+def test_project_a_summary(project_a: PlcProjectMetadata):
+    summary = project_a.summary
+
+    assert list(summary.function_blocks) == ["FB_ProjectA"]
+
+    fb_projecta = summary.function_blocks["FB_ProjectA"]
+    assert list(fb_projecta.declarations) == ["fValue"]
+    assert fb_projecta.declarations["fValue"].base_type == "LREAL"
+    assert "fValue := 1.0;" in str(fb_projecta.implementation)
+
+    st_projecta = summary.data_types["ST_ProjectA"]
+    assert list(st_projecta.declarations) == ["iValue"]
+    assert st_projecta.declarations["iValue"].base_type == "INT"
+
+    main = summary.programs["MAIN"]
+    assert main.implementation is None
+    assert list(main.declarations) == []
+
+    gvl = summary.globals["GVL_ProjectA"]
+    gvl_bprojecta = gvl.declarations["bProjectA"]
+    assert gvl_bprojecta.base_type == "BOOL"
+    assert isinstance(gvl_bprojecta.item.init, tf.TypeInitialization)
+    assert str(gvl_bprojecta.item.init.value) == "FALSE"
+
+
+@pytest.fixture
+def project_b(store: DependencyStore) -> PlcProjectMetadata:
+    # This is project b from the git submodule included with the blark test
+    # suite
+    proj, = store.get_dependency("project_b")
+    return proj
+
+
+def test_project_b_summary(project_b: PlcProjectMetadata):
+    summary = project_b.summary
+
+    st_projectb = summary.data_types["ST_ProjectB"]
+    assert list(st_projectb.declarations) == ["iProjectB"]
+    assert st_projectb.declarations["iProjectB"].base_type == "INT"
+
+    main = summary.programs["MAIN"]
+    assert str(main.implementation) == "fbLogger();"
+    assert list(main.declarations) == ["bProjectB", "fbLogger"]
+
+    gvl = summary.globals["GVL_ProjectB"]
+    gvl_bprojecta = gvl.declarations["bProjectB"]
+    assert gvl_bprojecta.base_type == "BOOL"
+    assert isinstance(gvl_bprojecta.item.init, tf.TypeInitialization)
+    assert gvl_bprojecta.item.init.value is None
+
+
+@pytest.fixture
+def twincat_general_281(store: DependencyStore) -> PlcProjectMetadata:
+    # This is project lcls-twincat-general v2.8.1 from the git submodule
+    # included with the blark test suite.
+    # This is *not* the full version from pcdshub/lcls-twincat-general, but
+    # rather a part of it for the purposes of the blark test suite.
+    proj, = store.get_dependency("LCLS_General", "v2.8.1")
+    return proj
+
+
+def test_twincat_general(twincat_general_281: PlcProjectMetadata):
+    summary = twincat_general_281.summary
+    assert list(summary.function_blocks) == ["FB_LogHandler"]
+    loghandler = summary.function_blocks["FB_LogHandler"]
+
+    check_declarations(
+        loghandler.declarations,
+        [
+            DeclarationCheck(
+                name="bLogHandlerInput",
+                base_type="BOOL",
+                value=None,
+            ),
+            DeclarationCheck(
+                name="nNumListeners",
+                base_type="UINT",
+                value="6",
+            ),
+            DeclarationCheck(
+                name="DisarmCountDefault",
+                base_type="UINT",
+                value="5",
+            ),
+        ]
+    )
+    # Ensure comments transferred over
+    impl = str(loghandler.implementation)
+    assert "Logic explanation" in impl
+    assert "// reset the count for the next" in impl
+    # Check about reformatting
+    assert "bTripCon := GVL_Logger.nGlobAccEvents > 0;" in impl
+
+    assert list(summary.globals) == ["DefaultGlobals", "Global_Variables_EtherCAT"]
+    ecat = summary.globals["Global_Variables_EtherCAT"]
+
+    check_declarations(
+        ecat.declarations,
+        [
+            DeclarationCheck(
+                name="iSLAVEADDR_ARR_SIZE",
+                base_type="UINT",
+                value="256",
+            ),
+            DeclarationCheck(
+                name="ESC_MAX_PORTS",
+                base_type="UINT",
+                value="3",
+                comments=["// Maximum number of ports (4) on ESC"],
+            ),
+        ]
+    )
+
+    defaults = summary.globals["DefaultGlobals"]
+
+    check_declarations(
+        defaults.declarations,
+        [
+            DeclarationCheck(
+                name="stSys",
+                base_type="ST_System",
+                comments=["//Included for you"],
+            ),
+            DeclarationCheck(
+                name="fTimeStamp",
+                base_type="LREAL",
+            ),
+        ]
+    )
+
+    system = summary.data_types["ST_System"]
+
+    check_declarations(
+        system.declarations,
+        [
+            DeclarationCheck(
+                name="xSwAlmRst",
+                base_type="BOOL",
+                comments=["(* Global Alarm Reset - EPICS Command *)"],
+            ),
+            DeclarationCheck(
+                name="xAtVacuum",
+                base_type="BOOL",
+                comments=["(* System At Vacuum *)"],
+            ),
+            DeclarationCheck(
+                name="xFirstScan",
+                base_type="BOOL",
+                comments=[
+                    "(* This boolean is true for the first scan, and is false "
+                    "thereafter, use for initialization of stuff *)",
+                ],
+            ),
+            DeclarationCheck(
+                name="xOverrideMode",
+                base_type="BOOL",
+                comments=[
+                    "//This bit is set when using the override features of the system"
+                ],
+            ),
+            DeclarationCheck(
+                name="xIOState",
+                base_type="BOOL",
+                comments=["(* ECat Bus Health *)"],
+            ),
+            DeclarationCheck(
+                name="I_EcatMaster1",
+                base_type="AMSNETID",
+                location="input",
+                comments=[
+                    "{attribute 'naming' := 'omit'}",
+                    "(* AMS Net ID used for FB_EcatDiag, among others *)"
+                ],
+            ),
+        ],
+    )

--- a/blark/tests/test_transformer.py
+++ b/blark/tests/test_transformer.py
@@ -34,11 +34,14 @@ def roundtrip_rule(rule_name: str, value: str, expected: Optional[str] = None):
         assert str(transformed) == expected, \
             "Transformed object does not produce identical source code"
     except Exception:
-        tree = parse_source_code(value, parser=parser, transform=False)
+        result = parse_source_code(value, parser=parser)
         print("\n\nTransformation failure. The original source code was:")
         print(value)
         print("\n\nThe parse tree is:")
-        print(tree.pretty())
+        if result is not None and result.tree is not None:
+            print(result.tree.pretty())
+        else:
+            print("None / unavailable")
         raise
 
     conftest.check_serialization(

--- a/blark/tests/test_transformer.py
+++ b/blark/tests/test_transformer.py
@@ -21,7 +21,9 @@ def roundtrip_rule(rule_name: str, value: str, expected: Optional[str] = None):
     3. Run serialization/deserialization checks (if enabled)
     """
     parser = conftest.get_grammar(start=rule_name)
-    transformed = parse_source_code(value, parser=parser)
+    tf_source = parse_source_code(value, parser=parser).transform()
+    transformed = tf_source.items[0]
+
     print("\n\nTransformed:")
     print(repr(transformed))
     print("\n\nOr:")
@@ -1422,7 +1424,8 @@ def test_miscellaneous(rule_name, value):
 )
 def test_global_types(value, init, base_type, full_type):
     parser = conftest.get_grammar(start="global_var_decl")
-    transformed = parse_source_code(value, parser=parser)
+    tf_source = parse_source_code(value, parser=parser).transform()
+    transformed = tf_source.items[0]
     assert isinstance(transformed, tf.GlobalVariableDeclaration)
     assert transformed.variables == ["fValue"]
 
@@ -1503,7 +1506,7 @@ def test_global_types(value, init, base_type, full_type):
     ]
 )
 def test_meta(code: str, comments: List[str], pragmas: List[str]):
-    transformed = parse_source_code(code)
+    transformed = parse_source_code(code).transform()
     meta = transformed.items[0].meta
     found_comments, found_pragmas = meta.get_comments_and_pragmas()
     assert [str(comment) for comment in found_comments] == comments

--- a/blark/tests/test_util.py
+++ b/blark/tests/test_util.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import pathlib
 import textwrap
 

--- a/blark/tests/test_util.py
+++ b/blark/tests/test_util.py
@@ -1,5 +1,6 @@
 import pathlib
 import textwrap
+from typing import Dict
 
 import pytest
 
@@ -199,7 +200,7 @@ def test_line_map(
     source: str,
     file_line: int,
     blark_line: int,
-    line_map: dict[int, int],
+    line_map: Dict[int, int],
 ):
     assert (
         util._build_source_to_file_line_map(file_line, blark_line, source) == line_map

--- a/blark/tests/test_util.py
+++ b/blark/tests/test_util.py
@@ -1,8 +1,11 @@
+import pathlib
 import textwrap
 
 import pytest
 
-from ..util import find_and_clean_comments
+from .. import util
+from ..input import BlarkCompositeSourceItem, BlarkSourceItem
+from ..util import SourceType, find_and_clean_comments
 
 
 @pytest.mark.parametrize(
@@ -58,7 +61,7 @@ from ..util import find_and_clean_comments
             id="nested_3",
             marks=pytest.mark.xfail(
                 reason="Comments replaced OK; whitespace handling needs work"
-            )
+            ),
         ),
         pytest.param(
             """
@@ -151,12 +154,13 @@ from ..util import find_and_clean_comments
             None,
             id="pragma_comment_why",
         ),
-    ]
+    ],
 )
 def test_replace_comments(code, expected):
     expected = expected if expected is not None else code
     comments, replaced = find_and_clean_comments(code, replace_char="x")
-    print(f"""
+    print(
+        f"""
 code:
 -----
 {code}
@@ -169,7 +173,8 @@ expected:
 -----
 {expected}
 -----
-""")
+"""
+    )
 
     assert replaced == expected
 
@@ -179,3 +184,87 @@ expected:
         expected_comments = [textwrap.dedent(code.lstrip("\n")).strip()]
     assert [str(comment) for comment in comments] == expected_comments
     print("comments=", comments)
+
+
+@pytest.mark.parametrize(
+    "source, file_line, blark_line, line_map",
+    [
+        ("a\nb\nc", 1, 1, {1: 1, 2: 2, 3: 3}),
+        ("a\nb\nc\nd", 10, 1, {1: 10, 2: 11, 3: 12, 4: 13}),
+        ("a\nb\nc", 1, 5, {5: 1, 6: 2, 7: 3}),
+        ("a\nb\nc\nd", 10, 5, {5: 10, 6: 11, 7: 12, 8: 13}),
+    ],
+)
+def test_line_map(
+    source: str,
+    file_line: int,
+    blark_line: int,
+    line_map: dict[int, int],
+):
+    assert (
+        util._build_source_to_file_line_map(file_line, blark_line, source) == line_map
+    )
+
+
+def test_line_map_composite():
+    composite = BlarkCompositeSourceItem(
+        type=SourceType.method,
+        parts=[
+            BlarkSourceItem(
+                file=pathlib.Path("FB_DummyHA.TcPOU"),
+                line=64,
+                type=SourceType.method,
+                code=(
+                    "\n"
+                    "METHOD RequestBP : BOOL\n"
+                    "VAR_INPUT\n"
+                    "\t(*StateID of state requesting beam parameter set*)\n"
+                    "\tnReqID\t: DWORD;\n"
+                    "\t(*Requested beam params*)\n"
+                    "\tstReqBP\t: ST_BeamParams;\n"
+                    "END_VAR\n"
+                ),
+                implicit_end=None,
+                grammar_rule="function_block_method_declaration",
+            ),
+            BlarkSourceItem(
+                file=pathlib.Path("FB_DummyHA.TcPOU"),
+                line=74,
+                type=SourceType.method,
+                code="RequestBP := TRUE;",
+                implicit_end=None,
+                grammar_rule="statement_list",
+            ),
+        ],
+        implicit_end="END_METHOD",
+        grammar_rule="function_block_method_declaration",
+    )
+
+    code, line_map = composite.get_code(include_end=True)
+    print(code)
+    expected_code = (
+        "\n"
+        "METHOD RequestBP : BOOL\n"
+        "VAR_INPUT\n"
+        "\t(*StateID of state requesting beam parameter set*)\n"
+        "\tnReqID\t: DWORD;\n"
+        "\t(*Requested beam params*)\n"
+        "\tstReqBP\t: ST_BeamParams;\n"
+        "END_VAR\n"
+        "RequestBP := TRUE;\n"  # <- line 9 is from line 74
+        "END_METHOD"  # <- line 10 is made up
+    )
+    assert code == expected_code
+
+    assert line_map == {
+        1: 64,
+        2: 65,
+        3: 66,
+        4: 67,
+        5: 68,
+        6: 69,
+        7: 70,
+        8: 71,
+        9: 74,
+        10: 74,
+    }

--- a/blark/transform.py
+++ b/blark/transform.py
@@ -2996,7 +2996,7 @@ class SourceCode:
     items: List[SourceCodeItem]
     filename: Optional[pathlib.Path] = None
     raw_source: Optional[str] = None
-    line_map: Optional[dict[int, int]] = None
+    line_map: Optional[Dict[int, int]] = None
     meta: Optional[Meta] = meta_field()
 
     @staticmethod

--- a/blark/transform.py
+++ b/blark/transform.py
@@ -2992,10 +2992,11 @@ class StatementList:
         return "\n".join(str(statement) for statement in self.statements)
 
 
-FunctionBlockBody = Union[
-    StatementList,
-]
+# FunctionBlockBody = Union[
+#     StatementList,
+# ]
 
+FunctionBlockBody = StatementList  # Only supported option, for now
 FunctionBody = FunctionBlockBody  # Identical, currently
 
 

--- a/blark/transform.py
+++ b/blark/transform.py
@@ -1275,7 +1275,7 @@ class ArrayInitialization:
 @dataclass
 @_rule_handler("object_initializer_array")
 class ObjectInitializerArray:
-    name: SymbolicVariable
+    name: lark.Token
     initializers: List[StructureInitialization]
     meta: Optional[Meta] = meta_field()
 

--- a/blark/transform.py
+++ b/blark/transform.py
@@ -3089,6 +3089,16 @@ class SourceCode:
         return "\n".join(str(item) for item in self.items)
 
 
+@dataclass
+class ExtendedSourceCode(SourceCode):
+    """
+    Top-level source code item - extended to include the possibility of
+    standalone implementation details (i.e., statement lists).
+    """
+
+    items: List[Union[SourceCodeItem, StatementList]]
+
+
 def _annotator_wrapper(handler):
     def wrapped(self: GrammarTransformer, data: Any, children: list, meta: lark.tree.Meta) -> Any:
         result = handler(*children)

--- a/blark/transform.py
+++ b/blark/transform.py
@@ -3236,6 +3236,55 @@ def merge_comments(source: Any, comments: List[lark.Token]):
                 merge_comments(obj, comments)
 
 
+def transform(
+    source_code: str,
+    tree: lark.Tree,
+    comments: Optional[list[lark.Token]] = None,
+    line_map: Optional[dict[int, int]] = None,
+    filename: Optional[pathlib.Path] = None,
+) -> SourceCode:
+    """
+    Transform a ``lark.Tree`` into dataclasses.
+
+    Parameters
+    ----------
+    source_code : str
+        The plain source code.
+    tree : lark.Tree
+        The parse tree from lark.
+    comments : list[lark.Token], optional
+        A list of pre-processed comments.
+    line_map : dict[int, int], optional
+        A map of lines from ``source_code`` to file lines.
+    filename : pathlib.Path, optional
+        The file associated with the source code.
+
+    Returns
+    -------
+    SourceCode
+    """
+    transformer = GrammarTransformer(
+        comments=list(comments or []),
+        fn=filename,
+        source_code=source_code,
+    )
+    transformed = transformer.transform(tree, line_map=line_map)
+
+    if isinstance(transformed, SourceCode):
+        return transformed
+
+    # TODO: this is for custom starting points and ignores that 'transformed'
+    # may not be a typical "SourceCodeItem". Goal is just returning a
+    # consistent SourceCode instance
+    return SourceCode(
+        items=[transformed],
+        filename=filename,
+        raw_source=source_code,
+        line_map=line_map,
+        meta=transformed.meta,
+    )
+
+
 Constant = Union[
     Duration,
     Lduration,

--- a/blark/transform.py
+++ b/blark/transform.py
@@ -13,7 +13,7 @@ from typing import (Any, Callable, ClassVar, Dict, Generator, List, Optional,
 
 import lark
 
-from .util import AnyPath
+from .util import AnyPath, rebuild_lark_tree_with_line_map
 
 T = TypeVar("T")
 
@@ -3061,7 +3061,13 @@ class GrammarTransformer(lark.visitors.Transformer_InPlaceRecursive):
         )
     )
 
-    def transform(self, tree):
+    def transform(self, tree: lark.Tree, *, line_map: Optional[dict[int, int]] = None):
+        if line_map is not None:
+            tree = rebuild_lark_tree_with_line_map(
+                tree,
+                code_line_to_file_line=line_map,
+            )
+
         transformed = super().transform(tree)
         if self.comments:
             merge_comments(transformed, self.comments)

--- a/blark/transform.py
+++ b/blark/transform.py
@@ -2984,6 +2984,7 @@ SourceCodeItem = Union[
     Action,
     Method,
     Program,
+    Property,
     GlobalVariableDeclarations,
 ]
 
@@ -2995,6 +2996,7 @@ class SourceCode:
     items: List[SourceCodeItem]
     filename: Optional[pathlib.Path] = None
     raw_source: Optional[str] = None
+    line_map: Optional[dict[int, int]] = None
     meta: Optional[Meta] = meta_field()
 
     @staticmethod

--- a/blark/typing.py
+++ b/blark/typing.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import pathlib
 import typing
-from typing import Callable, Union, overload
+from typing import Callable, Optional, Union, overload
 
 __all__ = ["Self"]
 
@@ -45,9 +45,12 @@ class ContainsBlarkCode(Protocol):
         ...
 
 
+# TODO: these got refactored out; any use for them?
+
+
 @runtime_checkable
 class SupportsRewrite(Protocol):
-    def rewrite_code(self, identifier: str, contents: str):
+    def rewrite_code(self, identifier: Optional[str], contents: str):
         ...
 
 
@@ -63,6 +66,6 @@ class SupportsWrite(Protocol):
 
 
 @runtime_checkable
-class SupportsCustomSave(Protocol):
+class SupportsSaveToPath(Protocol):
     def save_to(self, path: AnyPath, **kwargs) -> None:
         ...

--- a/blark/typing.py
+++ b/blark/typing.py
@@ -33,6 +33,9 @@ AnyBlarkSourceItem = Union["BlarkCompositeSourceItem", "BlarkSourceItem"]
 Preprocessor = Callable[[str], str]
 
 
+DeclarationOrImplementation = Literal["declaration", "implementation"]
+
+
 @runtime_checkable
 class ContainsBlarkCode(Protocol):
     """Indicates that the given class can emit blark-compatible source items."""

--- a/blark/typing.py
+++ b/blark/typing.py
@@ -1,13 +1,14 @@
 from __future__ import annotations
 
+import pathlib
 import typing
-from typing import Union, overload
+from typing import Callable, Union, overload
 
 __all__ = ["Self"]
 
 
 if typing.TYPE_CHECKING:
-    from .util import BlarkCompositeSourceItem, BlarkSourceItem
+    from .input import BlarkCompositeSourceItem, BlarkSourceItem
 
 
 try:
@@ -21,8 +22,16 @@ except ImportError:
     from typing_extensions import Self
 
 
+#: Support both pathlib paths and regular strings with AnyPath:
+AnyPath = Union[str, pathlib.Path]
+AnyBlarkSourceItem = Union["BlarkCompositeSourceItem", "BlarkSourceItem"]
+Preprocessor = Callable[[str], str]
+
+
 @runtime_checkable
 class ContainsBlarkCode(Protocol):
+    """Indicates that the given class can emit blark-compatible source items."""
+
     @overload
     def to_blark(self) -> list[BlarkSourceItem]:
         ...
@@ -32,5 +41,28 @@ class ContainsBlarkCode(Protocol):
         ...
 
     @overload
-    def to_blark(self) -> list[Union[BlarkSourceItem, BlarkCompositeSourceItem]]:
+    def to_blark(self) -> list[AnyBlarkSourceItem]:
+        ...
+
+
+@runtime_checkable
+class SupportsRewrite(Protocol):
+    def rewrite_code(self, contents: str):
+        ...
+
+
+@runtime_checkable
+class SupportsWrite(Protocol):
+    @overload
+    def to_file_contents(self, **kwargs) -> str:
+        ...
+
+    @overload
+    def to_file_contents(self, **kwargs) -> bytes:
+        ...
+
+
+@runtime_checkable
+class SupportsCustomSave(Protocol):
+    def save_to(self, path: AnyPath, **kwargs) -> None:
         ...

--- a/blark/typing.py
+++ b/blark/typing.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import typing
-from typing import Union, overload
+from typing import Dict, Union, overload
 
 if typing.TYPE_CHECKING:
     from .util import BlarkCompositeSourceItem, BlarkSourceItem
@@ -28,4 +28,4 @@ class ContainsBlarkCode(Protocol):
         ...
 
 
-BlarkLineToFileLine = dict[int, int]
+BlarkLineToFileLine = Dict[int, int]

--- a/blark/typing.py
+++ b/blark/typing.py
@@ -1,7 +1,10 @@
 from __future__ import annotations
 
 import typing
-from typing import Dict, Union, overload
+from typing import Union, overload
+
+__all__ = ["Self"]
+
 
 if typing.TYPE_CHECKING:
     from .util import BlarkCompositeSourceItem, BlarkSourceItem
@@ -12,20 +15,22 @@ try:
 except ImportError:
     from typing_extensions import Protocol, runtime_checkable
 
+try:
+    from typing import Self
+except ImportError:
+    from typing_extensions import Self
+
 
 @runtime_checkable
 class ContainsBlarkCode(Protocol):
-    @overload
-    def to_blark(self) -> list[BlarkCompositeSourceItem]:
-        ...
-
     @overload
     def to_blark(self) -> list[BlarkSourceItem]:
         ...
 
     @overload
-    def to_blark(self) -> list[Union[BlarkSourceItem, BlarkCompositeSourceItem]]:
+    def to_blark(self) -> list[BlarkCompositeSourceItem]:
         ...
 
-
-BlarkLineToFileLine = Dict[int, int]
+    @overload
+    def to_blark(self) -> list[Union[BlarkSourceItem, BlarkCompositeSourceItem]]:
+        ...

--- a/blark/typing.py
+++ b/blark/typing.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+import typing
+from typing import Union, overload
+
+if typing.TYPE_CHECKING:
+    from .util import BlarkCompositeSourceItem, BlarkSourceItem
+
+
+try:
+    from typing import Protocol, runtime_checkable
+except ImportError:
+    from typing_extensions import Protocol, runtime_checkable
+
+
+@runtime_checkable
+class ContainsBlarkCode(Protocol):
+    @overload
+    def to_blark(self) -> list[BlarkCompositeSourceItem]:
+        ...
+
+    @overload
+    def to_blark(self) -> list[BlarkSourceItem]:
+        ...
+
+    @overload
+    def to_blark(self) -> list[Union[BlarkSourceItem, BlarkCompositeSourceItem]]:
+        ...
+
+
+BlarkLineToFileLine = dict[int, int]

--- a/blark/typing.py
+++ b/blark/typing.py
@@ -4,7 +4,12 @@ import pathlib
 import typing
 from typing import Callable, Optional, Union, overload
 
-__all__ = ["Self"]
+try:
+    from typing import Literal
+except ImportError:
+    from typing_extensions import Literal
+
+__all__ = ["Self", "Literal"]
 
 
 if typing.TYPE_CHECKING:

--- a/blark/typing.py
+++ b/blark/typing.py
@@ -47,7 +47,7 @@ class ContainsBlarkCode(Protocol):
 
 @runtime_checkable
 class SupportsRewrite(Protocol):
-    def rewrite_code(self, contents: str):
+    def rewrite_code(self, identifier: str, contents: str):
         ...
 
 

--- a/blark/util.py
+++ b/blark/util.py
@@ -24,6 +24,7 @@ class SourceType(enum.Enum):
     property_get = enum.auto()
     property_set = enum.auto()
     struct = enum.auto()
+    statement_list = enum.auto()
     var_global = enum.auto()
 
     def __str__(self) -> str:
@@ -41,6 +42,7 @@ class SourceType(enum.Enum):
             SourceType.property: "function_block_property_declaration",
             SourceType.property_get: "function_block_property_declaration",
             SourceType.property_set: "function_block_property_declaration",
+            SourceType.statement_list: "statement_list",
             SourceType.struct: "data_type_declaration",
             # NOTE: multiple definitions can be present in GVLs:
             SourceType.var_global: "iec_source",
@@ -57,6 +59,7 @@ class SourceType(enum.Enum):
             SourceType.property: "END_PROPERTY",
             SourceType.property_get: "",
             SourceType.property_set: "",
+            SourceType.statement_list: "",
             SourceType.struct: "",
             SourceType.var_global: "",
         }[self]

--- a/blark/util.py
+++ b/blark/util.py
@@ -4,12 +4,13 @@ import enum
 import hashlib
 import pathlib
 import re
-from typing import Any, Dict, Generator, List, Optional, Tuple, TypeVar, Union
+from typing import Any, Dict, Generator, List, Optional, Tuple, TypeVar
 
 import lark
 
+from .typing import AnyPath  # Back-compat
+
 RE_LEADING_WHITESPACE = re.compile("^[ \t]+", re.MULTILINE)
-AnyPath = Union[str, pathlib.Path]
 
 
 class SourceType(enum.Enum):
@@ -152,8 +153,12 @@ def find_pou_type_and_identifier(code: str) -> tuple[Optional[SourceType], Optio
     for line in clean_code.splitlines():
         parts = line.lstrip().split(None, 2)
         if parts and parts[0].lower() in types:
-            identifier = parts[1] if len(parts) >= 2 else ""
-            return SourceType[parts[0].lower()], identifier
+            source_type = SourceType[parts[0].lower()]
+            if source_type == SourceType.var_global:
+                identifier = None
+            else:
+                identifier = parts[1] if len(parts) >= 2 else ""
+            return source_type, identifier
     return None, None
 
 

--- a/blark/util.py
+++ b/blark/util.py
@@ -39,7 +39,7 @@ class SourceType(enum.Enum):
 
     def get_grammar_rule(self) -> str:
         return {
-            SourceType.action: "action",
+            SourceType.action: "statement_list",
             SourceType.function: "function_declaration",
             SourceType.function_block: "function_block_type_declaration",
             SourceType.general: "iec_source",
@@ -58,7 +58,7 @@ class SourceType(enum.Enum):
 
     def get_implicit_block_end(self) -> str:
         return {
-            SourceType.action: "END_ACTION",
+            SourceType.action: "",
             SourceType.function: "END_FUNCTION",
             SourceType.function_block: "END_FUNCTION_BLOCK",
             SourceType.general: "",

--- a/blark/util.py
+++ b/blark/util.py
@@ -163,13 +163,21 @@ def find_pou_type_and_identifier(code: str) -> tuple[Optional[SourceType], Optio
     types = {source.name for source in SourceType}
     clean_code = remove_all_comments(code)
     for line in clean_code.splitlines():
-        parts = line.lstrip().split(None, 2)
+        parts = line.lstrip().split()
         if parts and parts[0].lower() in types:
             source_type = SourceType[parts[0].lower()]
-            if source_type == SourceType.var_global:
-                identifier = None
-            else:
-                identifier = parts[1] if len(parts) >= 2 else ""
+            identifier = None
+            if source_type != SourceType.var_global:
+                for identifier in parts[1:]:
+                    if identifier.lower() not in {
+                        "abstract",
+                        "public",
+                        "private",
+                        "protected",
+                        "internal",
+                        "final",
+                    }:
+                        break
             return source_type, identifier
     return None, None
 

--- a/blark/util.py
+++ b/blark/util.py
@@ -4,7 +4,7 @@ import enum
 import hashlib
 import pathlib
 import re
-from typing import Any, Dict, Generator, List, Optional, Tuple, TypeVar
+from typing import Any, Dict, Generator, List, Optional, Set, Tuple, TypeVar
 
 import lark
 import lxml.etree
@@ -531,6 +531,7 @@ def tree_to_xml_source(
     xml_header: str = '<?xml version="1.0" encoding="{encoding}"?>',
     indent: str = "  ",
 ) -> bytes:
+    """Return the contents to write for the given XML tree."""
     # NOTE: we avoid lxml.etree.tostring(xml_declaration=True) as we want
     # to write a declaration that matches what TwinCAT writes. It uses double
     # quotes instead of single quotes.
@@ -547,3 +548,13 @@ def tree_to_xml_source(
 
     source_lines = source.split(b"\n")
     return delimiter.encode(encoding).join(source_lines)
+
+
+def recursively_remove_keys(obj, keys: Set[str]) -> Any:
+    """Remove the provided keys from the JSON object."""
+    if isinstance(obj, dict):
+        return {key: recursively_remove_keys(value, keys) for key, value in obj.items()
+                if key not in keys}
+    if isinstance(obj, (list, tuple)):
+        return [recursively_remove_keys(value, keys) for value in obj]
+    return obj

--- a/blark/util.py
+++ b/blark/util.py
@@ -20,6 +20,7 @@ CLOSE_PRAGMA = "}"
 
 
 class SourceType(enum.Enum):
+    general = enum.auto()
     action = enum.auto()
     function = enum.auto()
     function_block = enum.auto()
@@ -41,6 +42,7 @@ class SourceType(enum.Enum):
             SourceType.action: "action",
             SourceType.function: "function_declaration",
             SourceType.function_block: "function_block_type_declaration",
+            SourceType.general: "iec_source",
             # TODO no grammar rule exists yet for 'INTERFACE'
             SourceType.interface: "iec_source",
             SourceType.method: "function_block_method_declaration",
@@ -59,6 +61,7 @@ class SourceType(enum.Enum):
             SourceType.action: "END_ACTION",
             SourceType.function: "END_FUNCTION",
             SourceType.function_block: "END_FUNCTION_BLOCK",
+            SourceType.general: "",
             SourceType.interface: "END_INTERFACE",
             SourceType.method: "END_METHOD",
             SourceType.program: "END_PROGRAM",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 lark>1.0
-pytmc
+lxml
 typing-extensions ; python_version < "3.11"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 lark>1.0
 lxml
+packaging
 typing-extensions ; python_version < "3.11"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 lark>1.0
 pytmc
+typing-extensions ; python_version < "3.11"


### PR DESCRIPTION
**If this breaks your usage of blark, let me know!**

This is a pretty large refactor/enhancement, comments/ideas/complaints are welcome.

## Goals

Primarily: to close https://github.com/klauer/blark/issues/53

More specifically (caveat: some goals may be walked back; some may not be written here yet) -
* Continue to support the current input formats (plain text `.st` files, and TwinCAT source code files)
* Remove dependency on pytmc (for code loading, the dependency store, and everything else).
* Require `lxml` for project parsing.
* Make file loading more easily customizable, with the option to load/save arbitrary file formats so long as you can provide an adapter (or for command-line input, code with metadata described by a JSON schema).
* Allow for mapping of blark input line numbers back to source code files
* Allow for in-place code rewriting of source code files (-> `blark format --write my_pou.TcPOU`)
* Redo `blark.parse()` and similar API functions to return a [consistent `dataclass`](https://github.com/klauer/blark/blob/04c98d554be58e26429b20e9de877c60f5cdca0e/blark/parse.py#L90-L102) type. This will group together the source code, a map of line numbers, the `lark.Tree`, and an option to easily transform it into `blark.transform.SourceCode` dataclasses.
* Redo the `blark parse` CLI as it's pretty bad in `master`
* Redo the `blark format` CLI to support these input/output formats and more closely mirror how `blark parse` will work

At some point after this PR, I might consider: 
* Adding `blark scrape` - a tool to scrape codebases and dump out the requested information. 
* Rewriting `pytmc pragmalint` (a tool for linting a specific set of pragmas in our TwinCAT projects) around the above. Piping results from `blark scrape --rule PRAGMA` into `pytmc pragmalint` could help refer back to actual line numbers in files. Our current linting method (as [exhibited here](https://github.com/pcdshub/pcds-ci-test-repo-twincat/pull/2/files#diff-9254954aace1730c56ad5eab8e270f03e5e8ea9e1b39705227e99977c454f1a4R12) is off by a few lines due to pytmc throwing away line number information)

### Status

* The solution parser looks to be working mostly fine for now
   * It needs more comments/docstrings like everything else here
   * `GlobalTextList` items are causing some failures ([example](https://github.com/pcdshub/lcls-plc-sxr-satt/blob/master/lcls-plc-sxr-satt/SolidAttenuatorPLC/GlobalTextList.TcGTLO))
* Dependency store might be OK, needs looking into
    * Test suite addition of a 'blark twincat root' is here: https://github.com/klauer/blark-twincat-root-example
    * The idea being you can load up libraries/projects and relate them to one another (maybe eventually paving the way for a TwinCAT LSP)
* Need to circle back and add more tests. Coverage is likely abysmal 
* Need to check if summary classes and sphinx domain need adjusting

### Example 

Take, for example, a TwinCAT POU like [FB_DummyHA.TcPOU](https://github.com/pcdshub/lcls-twincat-pmps/blob/294789452e90c3b9b46a28b103f3e16f56fe198d/lcls-twincat-pmps/PMPS/HelperFunctions/FB_DummyHA.TcPOU).
It's broken up into multiple XML sections, which we have no interest in adding grammar for.

#### In blark master:
* We require that this file get flattened into something like this:
<details>
<summary>FB_DummyHA blark-parse-able source</summary>

```bash
FUNCTION_BLOCK FB_DummyHA IMPLEMENTS I_HigherAuthority, I_LowerAuthority
VAR_INPUT
    ReqAcknowledged : BOOL := TRUE; // Use to control when the HA CHeckRequest Returns TRUE
END_VAR
VAR_OUTPUT
END_VAR
VAR
END_VAR


END_FUNCTION_BLOCK

METHOD CheckRequest : BOOL
VAR_INPUT
        nReqID  : DWORD;
END_VAR
CheckRequest := ReqAcknowledged;
END_METHOD

// <Arbiter Internal>
// Elevates the arbitrated BP set to something above.
// Could be another arbiter, or a BP requester/ IO,
// or an FB that locks in a specific portion of the BP set.
METHOD ElevateRequest : BOOL
VAR_INPUT
    HigherAuthority : I_HigherAuthority;
END_VAR

END_METHOD

METHOD RemoveRequest : BOOL
VAR_INPUT
        (*StateID to remove*)
        nReqID  : DWORD;
END_VAR
RemoveRequest := TRUE;
END_METHOD

METHOD RequestBP : BOOL
VAR_INPUT
        (*StateID of state requesting beam parameter set*)
        nReqID  : DWORD;
        (*Requested beam params*)
        stReqBP : ST_BeamParams;
END_VAR
RequestBP := TRUE;
END_METHOD

PROPERTY nLowerAuthorityID : DWORD
VAR
END_VAR
nLowerAuthorityID := PMPS_GVL.EXCLUDED_ASSERTION_ID;
END_PROPERTY
```
</details>

* The library pytmc handles the project parsing and code extraction. Try `pytmc code lcls-twincat-pmps/PMPS/HelperFunctions/FB_DummyHA.TcPOU` and you should be able to get the same output.
* Now imagine if there's a syntax error in there somewhere, or we want to rewrite a certain section of this code to reformat it (or mutate it in any other way). The line numbers that blark sees no longer match up with what's in the XML.

#### After this PR is finished

* blark will handle determining file type formats on its own (currently only by filename extension; -> `blark.input`)
* blark will be able to introspect TwinCAT solutions, projects, and individual source code files (-> `blark.solution`)
* The parsed code items from the solution will produce implementation-agnostic instances of `BlarkSourceItem` (or `BlarkCompositeSourceItem`). `BlarkSourceItem` s may contain:
   * An the identifier of what's being parsed
   * A filename, if applicable
   * A map of line numbers
   * An optional grammar rule it should be parsed with
   * A user-specified object to go along with it
* Composite ones intend to just group those items together

In our above example:
* `blark parse FB_DummyHA.TcPOU`  would be routed through `blark.solution` due to its TwinCAT file extension
* The solution class `TcPOU` would generate `BlarkSourceItems` for each part, which may be wrapped into a `BlarkCompositeSourceItem` with identifier `FB_DummyHA`:
```
[1] FB_DummyHA/declaration (function_block)
[2] FB_DummyHA.CheckRequest/declaration (method)
[3] FB_DummyHA.CheckRequest/implementation (method)
[4] FB_DummyHA.ElevateRequest/declaration (method)
[5] FB_DummyHA.nLowerAuthorityID.get/declaration (property)
[6] FB_DummyHA.nLowerAuthorityID.get/implementation (property)
[7] FB_DummyHA.RemoveRequest/declaration (method)
[8] FB_DummyHA.RemoveRequest/implementation (method)
[9] FB_DummyHA.RequestBP/declaration (method)
[10] FB_DummyHA.RequestBP/implementation (method)
```
* Each of these generates its own line number map

## What about other input/output formats?

I haven't decided, maybe one or more of the following paths forward:

* I might be OK with including other input/output formats in the blark codebase if they aren't overly complicated/heavy (PLC Open XML? What do other codesys-using vendor projects look like?)
* Alternatively, input/output plugins could be a thing
* Failing that, suggesting users use blark as a library - or rely on JSON as an interchange format - could be OK