### PR TITLE
Support arrays of arrays

### DIFF
--- a/blark/iec.lark
+++ b/blark/iec.lark
@@ -331,6 +331,7 @@ _array_spec_type: STRING_TYPE
                 | function_call
                 | non_generic_type_name
                 | object_initializer_array
+                | array_specification
 
 object_initializer_array: function_block_type_name "[" structure_initialization ( "," structure_initialization )* "]"
 

--- a/blark/iec.lark
+++ b/blark/iec.lark
@@ -344,6 +344,7 @@ array_initial_element: ( integer | enumerated_value ) "(" [ _array_initial_eleme
 _array_initial_element: constant
                       | structure_initialization
                       | enumerated_value
+                      | array_initialization
 
 structure_type_declaration: structure_type_name_declaration [ extends ] ":" [ indirection_type ] "STRUCT"i ( structure_element_declaration ";"+ )* "END_STRUCT"i
 

--- a/blark/tests/source/array_of_arrays.st
+++ b/blark/tests/source/array_of_arrays.st
@@ -1,0 +1,12 @@
+{attribute 'hide'}
+METHOD prv_Detection : BOOL
+VAR_IN_OUT
+        currentChannel : ARRAY[APhase..CPhase] OF ARRAY [1..5] OF INT := [
+                [1, 2, 3, 4, 5],
+                [1, 2, 3, 4, 5],
+                [1, 2, 3, 4, 5]
+        ];
+END_VAR
+
+// do some stuff
+END_METHOD

--- a/blark/tests/test_transformer.py
+++ b/blark/tests/test_transformer.py
@@ -272,6 +272,8 @@ def test_bool_literal_roundtrip(name, value, expected):
         param("array_type_declaration", "TypeName : ARRAY [1..2, 3..4] OF INT := [2(3), 3(4)]"),
         param("array_type_declaration", "TypeName : ARRAY [1..2, 3..4] OF Tc.SomeType"),
         param("array_type_declaration", "TypeName : ARRAY [1..2, 3..4] OF Tc.SomeType(someInput := 3)"),  # noqa: E501
+        param("array_type_declaration", "TypeName : ARRAY [1..2, 3..4] OF ARRAY [1..2] OF INT"),
+        param("array_type_declaration", "TypeName : ARRAY [1..2, 3..4] OF ARRAY [1..2] OF ARRAY [3..4] OF INT"),  # noqa: E501
         param("structure_type_declaration", "TypeName :\nSTRUCT\nEND_STRUCT"),
         param("structure_type_declaration", "TypeName EXTENDS Other.Type :\nSTRUCT\nEND_STRUCT"),
         param("structure_type_declaration", "TypeName : POINTER TO\nSTRUCT\nEND_STRUCT"),
@@ -1420,6 +1422,12 @@ def test_miscellaneous(rule_name, value):
             tf.ArrayTypeInitialization,
             "INT",
             "ARRAY [1..10] OF INT",
+        ),
+        param(
+            "fValue : ARRAY [1..10] OF ARRAY [1..10] OF INT;",
+            tf.ArrayTypeInitialization,
+            "INT",
+            "ARRAY [1..10] OF ARRAY [1..10] OF INT",
         ),
         param(
             "fValue : FB_Test(1, 2, 3);",

--- a/blark/transform.py
+++ b/blark/transform.py
@@ -3247,6 +3247,7 @@ ArrayInitialElementType = Union[
     Constant,
     StructureInitialization,
     EnumeratedValue,
+    ArrayInitialization,
 ]
 
 

--- a/blark/transform.py
+++ b/blark/transform.py
@@ -1166,7 +1166,7 @@ class IndirectSimpleSpecification:
 @dataclass
 @_rule_handler("array_specification")
 class ArraySpecification:
-    type: Union[DataType, FunctionCall, ObjectInitializerArray]
+    type: Union[DataType, FunctionCall, ObjectInitializerArray, ArraySpecification]
     subranges: List[Subrange]
     meta: Optional[Meta] = meta_field()
 
@@ -1175,6 +1175,8 @@ class ArraySpecification:
         """The base type name."""
         if isinstance(self.type, DataType):
             return self.type.type_name
+        if isinstance(self.type, ArraySpecification):
+            return self.type.base_type_name
         return str(self.type.name)
 
     @property


### PR DESCRIPTION
## Related Issues

* #65 

## Changes

* Allow arrays to consist of arrays to support indeterminate nesting (I don't know if there's a compiler-imposed limit, but it certainly makes sense there would be a behavioral limit).
* Add relevant tests to confirm behavior.

### Closing Thoughts

I think this one should be pretty simple. I'm thankful for that! No rush to get this merged in (please enjoy your time away and don't review until you return).