### PR TITLE
Resolve RETURN and CONTINUE Overly-Greedy Matching

### DIFF
--- a/blark/iec.lark
+++ b/blark/iec.lark
@@ -791,6 +791,6 @@ while_statement: "WHILE"i expression "DO"i statement_list "END_WHILE"i ";"*
 
 repeat_statement: "REPEAT"i statement_list "UNTIL"i expression "END_REPEAT"i ";"*
 
-exit_statement.1: "EXIT"i ";"*
+exit_statement.1: "EXIT"i ";"+
 
 continue_statement.1: "CONTINUE"i ";"+

--- a/blark/iec.lark
+++ b/blark/iec.lark
@@ -749,7 +749,7 @@ reset_statement: _variable "R="i expression ";"+
 reference_assignment_statement: _variable "REF="i expression ";"+
 
 // B.3.2.2
-return_statement.1: "RETURN"i ";"*
+return_statement.1: "RETURN"i ";"+
 // return_statement: priority > 0 so that it doesn't clash with no_op_statement
 
 function_call_statement: function_call ";"+
@@ -793,4 +793,4 @@ repeat_statement: "REPEAT"i statement_list "UNTIL"i expression "END_REPEAT"i ";"
 
 exit_statement.1: "EXIT"i ";"*
 
-continue_statement.1: "CONTINUE"i ";"*
+continue_statement.1: "CONTINUE"i ";"+

--- a/blark/tests/test_transformer.py
+++ b/blark/tests/test_transformer.py
@@ -776,6 +776,51 @@ def test_type_name_roundtrip(rule_name, value):
         param("function_block_type_declaration", tf.multiline_code_block(
             """
             FUNCTION_BLOCK fbName
+                iValue := 1;
+                IF 1 THEN
+                    iValue := 1;
+                    IF 1 THEN
+                        iValue := 1;
+                    END_IF
+                END_IF
+                Method();
+                ReturnStatus := mReturnStatus;
+            END_FUNCTION_BLOCK
+            """
+        )),
+        param("function_block_type_declaration", tf.multiline_code_block(
+            """
+            FUNCTION_BLOCK fbName
+                iValue := 1;
+                IF 1 THEN
+                    iValue := 1;
+                    IF 1 THEN
+                        iValue := 1;
+                    END_IF
+                END_IF
+                Method();
+                ContinueWorking := somethingElse;
+            END_FUNCTION_BLOCK
+            """
+        )),
+        param("function_block_type_declaration", tf.multiline_code_block(
+            """
+            FUNCTION_BLOCK fbName
+                iValue := 1;
+                IF 1 THEN
+                    iValue := 1;
+                    IF 1 THEN
+                        iValue := 1;
+                    END_IF
+                END_IF
+                Method();
+                BreakWork := somethingElse;
+            END_FUNCTION_BLOCK
+            """
+        )),
+        param("function_block_type_declaration", tf.multiline_code_block(
+            """
+            FUNCTION_BLOCK fbName
                 Method();
                 IF 1 THEN
                     EXIT;

--- a/blark/tests/test_transformer.py
+++ b/blark/tests/test_transformer.py
@@ -821,6 +821,21 @@ def test_type_name_roundtrip(rule_name, value):
         param("function_block_type_declaration", tf.multiline_code_block(
             """
             FUNCTION_BLOCK fbName
+                iValue := 1;
+                IF 1 THEN
+                    iValue := 1;
+                    IF 1 THEN
+                        iValue := 1;
+                    END_IF
+                END_IF
+                Method();
+                ExitWork := somethingElse;
+            END_FUNCTION_BLOCK
+            """
+        )),
+        param("function_block_type_declaration", tf.multiline_code_block(
+            """
+            FUNCTION_BLOCK fbName
                 Method();
                 IF 1 THEN
                     EXIT;


### PR DESCRIPTION
## Related Issues

* #67 

## Changes

* Use `+` instead of `*` in `iec.lark` grammar for RETURN statement to require 1 or more semicolons instead of 0 or more.
* Use `+` instead of `*` in `iec.lark` grammar for CONTINUE statement to require 1 or more semicolons instead of 0 or more.
* Tests to validate behavior and appropriate parsing.

## Blocked By:

* #66 (this PR contains those same changes, so we should probably merge it first 😝 )

### Closing Thoughts

This looks like a much simpler change than I had anticipated. Very excited about that! :smile: