### PR TITLE
FIX: string length expression

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.9", "3.10", "3.11"]
 
     env:
       PYTHON: ${{ matrix.python-version }}

--- a/blark/iec.lark
+++ b/blark/iec.lark
@@ -198,9 +198,7 @@ TYPE_LDATETIME: "LDATE_AND_TIME"i
 ?elementary_type_name: NUMERIC_TYPE_NAME
                      | DATE_TYPE_NAME
                      | BIT_STRING_TYPE_NAME
-                     | string_type
-
-string_type: ( STRING | WSTRING ) WS* [ _string_spec_length ]
+                     | string_type_specification
 
 NUMERIC_TYPE_NAME: INTEGER_TYPE_NAME
                  | REAL_TYPE_NAME
@@ -327,7 +325,7 @@ array_spec_init: [ indirection_type ] array_specification [ ":=" array_initializ
 
 array_specification: "ARRAY"i "[" subrange ( "," subrange )* "]" "OF"i _array_spec_type
 
-_array_spec_type: string_type
+_array_spec_type: string_type_specification
                 | function_call
                 | non_generic_type_name
                 | object_initializer_array
@@ -361,7 +359,7 @@ structure_initialization: "(" structure_element_initialization ( "," structure_e
 structure_element_initialization: constant
                                 | structure_element_name ":=" ( constant | expression | enumerated_value | array_initialization | structure_initialization )
 
-string_type_declaration: string_type_name ":" ( STRING | WSTRING ) [ _string_spec_length ] [ ":=" string_literal ]
+string_type_declaration: string_type_name ":" string_type_specification [ ":=" string_literal ]
 
 // B.1.4
 _variable: direct_variable
@@ -505,19 +503,16 @@ global_var_list: global_var_name ( "," global_var_name )*
 
 single_byte_string_var_declaration: var1_list ":" single_byte_string_spec
 
-_string_spec_length_value: ( INTEGER | DOTTED_IDENTIFIER ) ( /[\+\-]/ ( INTEGER | DOTTED_IDENTIFIER ) )*
+bracketed_expression: "[" expression "]"
 
-string_length_parenthesized: "(" _string_spec_length_value ")"
-string_length_bracketized: "[" _string_spec_length_value "]"
+string_spec_length: parenthesized_expression
+                  | bracketed_expression
 
-_string_spec_length: string_length_bracketized
-                   | string_length_parenthesized
-
-!single_byte_string_spec: "STRING"i [ _string_spec_length ] [ ":=" SINGLE_BYTE_CHARACTER_STRING ]
+single_byte_string_spec: STRING [ string_spec_length ] [ ":=" SINGLE_BYTE_CHARACTER_STRING ]
 
 double_byte_string_var_declaration: var1_list ":" double_byte_string_spec
 
-!double_byte_string_spec: "WSTRING"i [ _string_spec_length ] [ ":=" DOUBLE_BYTE_CHARACTER_STRING ]
+double_byte_string_spec: WSTRING [ string_spec_length ] [ ":=" DOUBLE_BYTE_CHARACTER_STRING ]
 
 incomplete_located_var_declarations: "VAR"i [ variable_attributes ] incomplete_located_var_decl* "END_VAR"i ";"*
 
@@ -527,8 +522,7 @@ incomplete_location: "AT"i /\%(I|Q|M)\*/
 STRING: "STRING"i
 WSTRING: "WSTRING"i
 
-string_type_specification: STRING [ _string_spec_length ]
-                         | WSTRING [ _string_spec_length ]
+string_type_specification: (STRING | WSTRING) [ string_spec_length ]
 
 ?var_spec: simple_specification
          | subrange_specification
@@ -716,7 +710,9 @@ UNARY_OPERATOR: LOGICAL_NOT
 
 function_call: symbolic_variable "(" [ param_assignment ( "," param_assignment )* ","? ] ")" DEREFERENCED?
 
-?primary_expression: "(" expression ")"      -> parenthesized_expression
+parenthesized_expression: "(" expression ")"
+
+?primary_expression: parenthesized_expression
                    | function_call
                    | _variable
                    | constant

--- a/blark/iec.lark
+++ b/blark/iec.lark
@@ -198,9 +198,9 @@ TYPE_LDATETIME: "LDATE_AND_TIME"i
 ?elementary_type_name: NUMERIC_TYPE_NAME
                      | DATE_TYPE_NAME
                      | BIT_STRING_TYPE_NAME
-                     | STRING_TYPE
+                     | string_type
 
-STRING_TYPE: ( STRING | WSTRING ) WS* [ STRING_SPEC_LENGTH ]
+string_type: ( STRING | WSTRING ) WS* [ _string_spec_length ]
 
 NUMERIC_TYPE_NAME: INTEGER_TYPE_NAME
                  | REAL_TYPE_NAME
@@ -327,7 +327,7 @@ array_spec_init: [ indirection_type ] array_specification [ ":=" array_initializ
 
 array_specification: "ARRAY"i "[" subrange ( "," subrange )* "]" "OF"i _array_spec_type
 
-_array_spec_type: STRING_TYPE
+_array_spec_type: string_type
                 | function_call
                 | non_generic_type_name
                 | object_initializer_array
@@ -361,7 +361,7 @@ structure_initialization: "(" structure_element_initialization ( "," structure_e
 structure_element_initialization: constant
                                 | structure_element_name ":=" ( constant | expression | enumerated_value | array_initialization | structure_initialization )
 
-string_type_declaration: string_type_name ":" ( STRING | WSTRING ) [ STRING_SPEC_LENGTH ] [ ":=" string_literal ]
+string_type_declaration: string_type_name ":" ( STRING | WSTRING ) [ _string_spec_length ] [ ":=" string_literal ]
 
 // B.1.4
 _variable: direct_variable
@@ -505,14 +505,19 @@ global_var_list: global_var_name ( "," global_var_name )*
 
 single_byte_string_var_declaration: var1_list ":" single_byte_string_spec
 
-STRING_SPEC_LENGTH: "[" ( INTEGER | DOTTED_IDENTIFIER ) "]"
-                  | "(" ( INTEGER | DOTTED_IDENTIFIER ) ")"
+_string_spec_length_value: ( INTEGER | DOTTED_IDENTIFIER ) ( /[\+\-]/ ( INTEGER | DOTTED_IDENTIFIER ) )*
 
-!single_byte_string_spec: "STRING"i [ STRING_SPEC_LENGTH ] [ ":=" SINGLE_BYTE_CHARACTER_STRING ]
+string_length_parenthesized: "(" _string_spec_length_value ")"
+string_length_bracketized: "[" _string_spec_length_value "]"
+
+_string_spec_length: string_length_bracketized
+                   | string_length_parenthesized
+
+!single_byte_string_spec: "STRING"i [ _string_spec_length ] [ ":=" SINGLE_BYTE_CHARACTER_STRING ]
 
 double_byte_string_var_declaration: var1_list ":" double_byte_string_spec
 
-!double_byte_string_spec: "WSTRING"i [ STRING_SPEC_LENGTH ] [ ":=" DOUBLE_BYTE_CHARACTER_STRING ]
+!double_byte_string_spec: "WSTRING"i [ _string_spec_length ] [ ":=" DOUBLE_BYTE_CHARACTER_STRING ]
 
 incomplete_located_var_declarations: "VAR"i [ variable_attributes ] incomplete_located_var_decl* "END_VAR"i ";"*
 
@@ -522,8 +527,8 @@ incomplete_location: "AT"i /\%(I|Q|M)\*/
 STRING: "STRING"i
 WSTRING: "WSTRING"i
 
-string_type_specification: STRING [ STRING_SPEC_LENGTH ]
-                         | WSTRING [ STRING_SPEC_LENGTH ]
+string_type_specification: STRING [ _string_spec_length ]
+                         | WSTRING [ _string_spec_length ]
 
 ?var_spec: simple_specification
          | subrange_specification

--- a/blark/tests/conftest.py
+++ b/blark/tests/conftest.py
@@ -64,7 +64,7 @@ def check_serialization(
             no_copy=True,
         )
     except Exception:
-        print(json.dumps(dataclasses.asdict(obj), indent=2))
+        print(dataclasses.asdict(obj))
         raise
 
     print(f"Serialized {type(obj)} to:")

--- a/blark/tests/test_transformer.py
+++ b/blark/tests/test_transformer.py
@@ -200,8 +200,48 @@ def test_literal(name, value, expected):
         param("double_byte_string_spec", 'WSTRING(g_Constant + 1) := "abc"'),
     ],
 )
-def test_literal_roundtrip(name, value):
+def test_literal_roundtrip(name: str, value: str):
     roundtrip_rule(name, value)
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        param("STRING(2_500_000)"),
+        param("STRING(Param.iLower)"),
+        param("STRING(Param.iLower * 2 + 10)"),
+        param("STRING(Param.iLower / 2 + 10)"),
+        param("STRING(Param.iLower * 2 MOD 10 + Param.iUpper)"),
+        param("STRING(Param.iLower XOR 2 + Param.iUpper)"),
+        #  -> Border '(Func() + Param.iUpper)' of array is no constant value
+        # param("STRING(Func() + Param.iUpper)"),
+        #  // size of string expected after "("
+        # param("STRING()"),
+        param("STRING(INT_TO_UDINT(10) + 1)"),
+        #  // oh yeah, ** is not a thing in TwinCAT ST (-> issue)
+        # param("STRING(10 ** 2 + 1)"),
+        #  // 'iValue := 2' of array is no constant value
+        # param("STRING(iValue := 2)"),
+        param("STRING(BOOL_TO_UINT(TRUE AND_THEN TRUE))"),
+        param("STRING(BOOL_TO_UINT(TRUE OR_ELSE FALSE))"),
+        param("STRING(BOOL_TO_UINT(1 <= 10))"),
+        param("STRING(BOOL_TO_UINT(1 >= 10))"),
+
+        param("STRING[2_500_000]"),
+        param("STRING[Param.iLower]"),
+        param("STRING[Param.iLower * 2 + 10]"),
+        param("STRING[Param.iLower / 2 + 10]"),
+        param("STRING[Param.iLower * 2 MOD 10 + Param.iUpper]"),
+        param("STRING[Param.iLower XOR 2 + Param.iUpper]"),
+        param("STRING[INT_TO_UDINT(10) + 1]"),
+        param("STRING[BOOL_TO_UINT(TRUE AND_THEN TRUE)]"),
+        param("STRING[BOOL_TO_UINT(TRUE OR_ELSE FALSE)]"),
+        param("STRING[BOOL_TO_UINT(1 <= 10)]"),
+        param("STRING[BOOL_TO_UINT(1 >= 10)]"),
+    ],
+)
+def test_string_type_specification(value: str):
+    roundtrip_rule("string_type_specification", value)
 
 
 @pytest.mark.parametrize(
@@ -1326,8 +1366,8 @@ def test_input_output_comments(rule_name, value):
             """
             VAR
                 iValue AT %Q* : INT;
-                sValue AT %I* : STRING [255];
-                wsValue AT %I* : WSTRING [255];
+                sValue AT %I* : STRING[255];
+                wsValue AT %I* : WSTRING[255];
             END_VAR
             """
         )),

--- a/blark/tests/test_transformer.py
+++ b/blark/tests/test_transformer.py
@@ -188,9 +188,16 @@ def test_literal(name, value, expected):
         param("single_byte_string_spec", "STRING[1]"),
         param("single_byte_string_spec", "STRING(1)"),
         param("single_byte_string_spec", "STRING(1) := 'abc'"),
+        param("single_byte_string_spec", "STRING(g_Constant)"),
+        param("single_byte_string_spec", "STRING(g_Constant + 1)"),
+        param("single_byte_string_spec", "STRING(1 + g_Constant)"),
+        param("single_byte_string_spec", "STRING(g_Constant + 1) := 'abc'"),
         param("double_byte_string_spec", "WSTRING[1]"),
         param("double_byte_string_spec", "WSTRING(1)"),
         param("double_byte_string_spec", 'WSTRING(1) := "abc"'),
+        param("double_byte_string_spec", "WSTRING(g_Constant)"),
+        param("double_byte_string_spec", "WSTRING(g_Constant + 1)"),
+        param("double_byte_string_spec", 'WSTRING(g_Constant + 1) := "abc"'),
     ],
 )
 def test_literal_roundtrip(name, value):
@@ -638,6 +645,9 @@ def test_global_attr_pragmas(rule_name: str, value: str, pragmas: List[str]):
         param("non_generic_type_name", "POINTER TO Package.FBName"),
         param("non_generic_type_name", "POINTER TO POINTER TO Package.FBName"),
         param("non_generic_type_name", "Package.FBName"),
+        param("non_generic_type_name", "POINTER TO STRING(255)"),
+        param("non_generic_type_name", "POINTER TO STRING(g_Constant + 1)"),
+        param("non_generic_type_name", "POINTER TO POINTER TO STRING(g_Constant + 1)"),
     ],
 )
 def test_type_name_roundtrip(rule_name, value):


### PR DESCRIPTION
## Context

Closes #70 

Building on @engineerjoe440 's branch

## Changes

### Continuous Integration
* CI will only test on Python 3.9+ going forward.
   * 3.7 and 3.8 will be considered unsupported - but some/most of blark may still work on them

### Grammar

* Added `bracketed_expression` used solely for string lengths as in `STRING[255]`
* Grammar change - terminal `STRING_TYPE` -> is now a rule `string_type_specification` as it must support expressions for length and not just simple integers/constants/terminals
* `string_spec_length` added to support both flavors of string type declaration lengths `STRING[255]` and `STRING(255)`

### Dataclasses
* Adjusted dataclasses to support the grammar changes
* `SimpleSpecification` gets a bit more complicated as its type is no longer just a string `Token`

### Test suite
* Added a bunch of TwinCAT-approved string declarations, which went beyond what I expected to compile
* Added some TwinCAT disapproved string declarations and commented them out, but perhaps they should be added and marked as strict xfail. blark might be more permissive here than it should be, though.