### PR TITLE
ENH: interface support

### DIFF
--- a/blark/iec.lark
+++ b/blark/iec.lark
@@ -26,6 +26,7 @@ _library_element_declaration: data_type_declaration
                             | function_block_type_declaration
                             | function_block_method_declaration
                             | function_block_property_declaration
+                            | interface_declaration
                             | program_declaration
                             | global_var_declarations
                             | action
@@ -637,6 +638,17 @@ program_access_decls: "VAR_ACCESS"i (program_access_decl ";"+)+ "END_VAR"i ";"*
 ?access_name: IDENTIFIER
 
 program_access_decl: access_name ":" symbolic_variable ":" non_generic_type_name [ access_direction ]
+
+// Beckhoff/codesys-specific INTERFACE definition describing variables, methods,
+// and properties of other POUs
+
+?interface_var_declaration: input_declarations
+                          | output_declarations
+                          | input_output_declarations
+                          | external_var_declarations
+                          | var_declarations
+
+interface_declaration: "INTERFACE"i IDENTIFIER [ extends ] interface_var_declaration* "END_INTERFACE"i ";"*
 
 // B.1.6
 ?step_name: IDENTIFIER

--- a/blark/parse.py
+++ b/blark/parse.py
@@ -48,6 +48,7 @@ class BlarkStartingRule(enum.Enum):
     function_block_type_declaration = enum.auto()
     function_declaration = enum.auto()
     global_var_declarations = enum.auto()
+    interface_declaration = enum.auto()
     program_declaration = enum.auto()
     statement_list = enum.auto()
 

--- a/blark/solution.py
+++ b/blark/solution.py
@@ -179,7 +179,11 @@ def filename_from_xml(xml: Optional[lxml.etree.Element]) -> Optional[pathlib.Pat
 
     if root.docinfo.URL is None:
         return None
-    return pathlib.Path(root.docinfo.URL)
+    url = str(root.docinfo.URL)
+    if url.startswith("file:/"):
+        # Note: this only seems to be necessary on Windows and I'm not entirely sure why
+        url = url[len("file:/"):]
+    return pathlib.Path(url)
 
 
 def get_child_text(

--- a/blark/tests/test_transformer.py
+++ b/blark/tests/test_transformer.py
@@ -1296,6 +1296,51 @@ def test_program_roundtrip(rule_name, value):
 
 
 @pytest.mark.parametrize(
+    "source",
+    [
+        param(
+            tf.multiline_code_block(
+                """
+                INTERFACE Itf
+                END_INTERFACE
+                """
+            )
+        ),
+        param(
+            tf.multiline_code_block(
+                """
+                INTERFACE Itf EXTENDS ItfBase
+                END_INTERFACE
+                """
+            )
+        ),
+        param(
+            tf.multiline_code_block(
+                """
+                INTERFACE Itf EXTENDS ItfBase
+                VAR
+                    iVar1 : INT;
+                END_VAR
+                VAR_INPUT
+                    iInputVar1 : INT;
+                END_VAR
+                VAR_OUTPUT
+                    iOutputVar1 : INT;
+                END_VAR
+                VAR_EXTERNAL
+                    iExternVar1 : INT;
+                END_VAR
+                END_INTERFACE
+                """
+            )
+        ),
+    ],
+)
+def test_interface_roundtrip(source: str):
+    roundtrip_rule("interface_declaration", source)
+
+
+@pytest.mark.parametrize(
     "rule_name, value",
     [
         param("input_output_declarations", tf.multiline_code_block(

--- a/blark/transform.py
+++ b/blark/transform.py
@@ -1281,8 +1281,8 @@ class ObjectInitializerArray:
 
     @staticmethod
     def from_lark(
-        function_block_type_name: SymbolicVariable,
-        *initializers: List[StructureInitialization]
+        function_block_type_name: lark.Token,
+        *initializers: StructureInitialization
     ) -> ObjectInitializerArray:
         return ObjectInitializerArray(
             name=function_block_type_name,

--- a/blark/transform.py
+++ b/blark/transform.py
@@ -2090,6 +2090,53 @@ class Program:
         )
 
 
+InterfaceVariableDeclarationBlock = Union[
+    "InputDeclarations",
+    "OutputDeclarations",
+    "InputOutputDeclarations",
+    "ExternalVariableDeclarations",
+    "VariableDeclarations",
+]
+
+
+@dataclass
+@_rule_handler("interface_declaration", comments=True)
+class Interface:
+    name: lark.Token
+    extends: Optional[Extends]
+    # TODO: want this to be tagged during serialization, so it's kept as
+    # VariableDeclarationBlock.  More specifically it is
+    # declarations: List[InterfaceVariableDeclarationBlock]
+    declarations: List[VariableDeclarationBlock]
+    meta: Optional[Meta] = meta_field()
+
+    @staticmethod
+    def from_lark(
+        name: lark.Token,
+        # access: Optional[AccessSpecifier],
+        extends: Optional[Extends],
+        *decls: VariableDeclarationBlock,
+    ) -> Interface:
+        return Interface(
+            name=name,
+            extends=extends,
+            declarations=list(decls),
+        )
+
+    def __str__(self) -> str:
+        header = f"INTERFACE {self.name}"
+        header = join_if(header, " ", self.extends)
+        return "\n".join(
+            line for line in
+            (
+                header,
+                *[str(declaration) for declaration in self.declarations],
+                "END_INTERFACE",
+            )
+            if line is not None
+        )
+
+
 @dataclass
 @_rule_handler("action", comments=True)
 class Action:

--- a/blark/util.py
+++ b/blark/util.py
@@ -4,6 +4,7 @@ import codecs
 import dataclasses
 import enum
 import hashlib
+import os
 import pathlib
 import re
 from typing import Any, Dict, Generator, List, Optional, Set, Tuple, TypeVar
@@ -522,7 +523,7 @@ def fix_case_insensitive_path(path: AnyPath) -> pathlib.Path:
                 part = all_files[part.lower()]
             except KeyError:
                 raise FileNotFoundError(
-                    f"Path does not exist:\n" f"{path}\n{new_path}/{part} missing"
+                    f"Path does not exist: {path}\n{new_path}{os.pathsep}{part} missing"
                 ) from None
         new_path = new_path / part
     return new_path.resolve()

--- a/blark/util.py
+++ b/blark/util.py
@@ -46,8 +46,7 @@ class SourceType(enum.Enum):
             SourceType.function: "function_declaration",
             SourceType.function_block: "function_block_type_declaration",
             SourceType.general: "iec_source",
-            # TODO no grammar rule exists yet for 'INTERFACE'
-            SourceType.interface: "iec_source",
+            SourceType.interface: "interface_declaration",
             SourceType.method: "function_block_method_declaration",
             SourceType.program: "program_declaration",
             SourceType.property: "function_block_property_declaration",


### PR DESCRIPTION
## Context

First pass at `INTERFACE` support.

Closes #16 

It wasn't possible to parse `TcIO` files with pytmc previously, but now with our built-in solution parser of #64 we can move forward with supporting interface files directly from TwinCAT projects.

Some additional fixes made their way in here, too.