### PR TITLE
FIX: Bugfix for expressions in initial array elements

### DIFF
--- a/blark/iec.lark
+++ b/blark/iec.lark
@@ -339,7 +339,7 @@ array_initialization: "[" array_initial_element ( "," array_initial_element )* "
 array_initial_element: ( integer | enumerated_value ) "(" [ _array_initial_element ] ")" -> array_initial_element_count
                      | _array_initial_element
 
-_array_initial_element: constant
+_array_initial_element: expression
                       | structure_initialization
                       | enumerated_value
                       | array_initialization

--- a/blark/tests/source/array_of_addresses.st
+++ b/blark/tests/source/array_of_addresses.st
@@ -1,0 +1,16 @@
+FUNCTION_BLOCK class_SomethingCool
+VAR
+        currentChannel : ARRAY[1..g_c_someConstant] OF POINTER TO struct_groupData :=
+                [       ADR(_object[1].someValue),
+                        ADR(_object[2].someValue),
+                        ADR(_object[3].someValue),
+                        ADR(_object[4].someValue),
+                        ADR(_object[5].someValue),
+                        ADR(_object[6].someValue),
+                        ADR(_object[7].someValue),
+                        ADR(_object[8].someValue),
+                        ADR(_object[9].someValue),
+                        ADR(_object[10].someValue)
+                ];
+END_VAR
+END_FUNCTION_BLOCK

--- a/blark/transform.py
+++ b/blark/transform.py
@@ -3373,7 +3373,7 @@ Constant = Union[
 
 
 ArrayInitialElementType = Union[
-    Constant,
+    Expression,
     StructureInitialization,
     EnumeratedValue,
     ArrayInitialization,


### PR DESCRIPTION
Closes #69 

This relaxes array initial elements to not just being constants, but general expressions.