### PR TITLE
Unused grammar rule clean-up and grammar coverage tests

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -20,6 +20,7 @@ jobs:
 
     env:
       PYTHON: ${{ matrix.python-version }}
+      BLARK_CHECK_GRAMMAR_COVERAGE: 1
 
     steps:
     - uses: actions/checkout@v3

--- a/blark/iec.lark
+++ b/blark/iec.lark
@@ -104,7 +104,7 @@ SINGLE_BYTE_CHARACTER: /[^$']/
 
 DOUBLE_BYTE_CHARACTER: /[^$"]/
                      | ESCAPE_CHARACTER
-                     | "$'"
+                     | "$\""
                      | "$" /[0-9A-F][0-9A-F][0-9A-F][0-9A-F]/
 
 SINGLE_BYTE_CHARACTER_STRING: "'" SINGLE_BYTE_CHARACTER* "'"

--- a/blark/iec.lark
+++ b/blark/iec.lark
@@ -448,8 +448,6 @@ var_body: ( var_init_decl ";"+ )*
 
 array_var_declaration: var1_list ":" array_specification
 
-structured_var_declaration: var1_list ":" structure_type_name
-
 var_declarations: "VAR"i [ variable_attributes ] var_body "END_VAR"i ";"*
 
 static_var_declarations: "VAR_STAT"i [ variable_attributes ] var_body "END_VAR"i ";"*
@@ -529,7 +527,6 @@ string_type_specification: (STRING | WSTRING) [ string_spec_length ]
          | subrange_specification
          | enumerated_specification
          | array_specification
-         | structure_type_name
          | string_type_specification
 
 // B.1.5.1
@@ -549,11 +546,6 @@ function_declaration: "FUNCTION"i [ access_specifier ] derived_function_name [ "
 function_var_declarations: "VAR"i [ variable_attributes ] var_body "END_VAR"i ";"*
 
 ?function_body: statement_list
-
-function_var_decl: var1_init_decl
-                 | array_var_init_decl
-                 | structured_var_init_decl
-                 | string_var_declaration
 
 // B.1.5.2
 DOTTED_IDENTIFIER: IDENTIFIER ( "." IDENTIFIER )*
@@ -648,11 +640,6 @@ program_access_decl: access_name ":" symbolic_variable ":" non_generic_type_name
                           | var_declarations
 
 interface_declaration: "INTERFACE"i IDENTIFIER [ extends ] interface_var_declaration* "END_INTERFACE"i ";"*
-
-// B.1.6
-?step_name: IDENTIFIER
-INITIAL_STEP: "INITIAL_STEP"i
-STEP: "STEP"i
 
 // B.2.1, B.3.1
 LOGICAL_OR: "OR"i

--- a/blark/transform.py
+++ b/blark/transform.py
@@ -1988,7 +1988,7 @@ class GlobalVariableDeclaration:
         return self.init.full_type_name
 
     def __str__(self) -> str:
-        return f"{self.spec} : {self.init}"
+        return f"{self.spec} : {self.init};"
 
 
 @dataclass
@@ -2721,7 +2721,7 @@ class GlobalVariableDeclarations(VariableDeclarationBlock):
         return "\n".join(
             (
                 join_if("VAR_GLOBAL", " ", self.attrs),
-                *(indent(f"{item};") for item in self.items),
+                *(indent(str(item)) for item in self.items),
                 "END_VAR",
             )
         )

--- a/blark/transform.py
+++ b/blark/transform.py
@@ -13,7 +13,7 @@ from typing import (Any, Callable, ClassVar, Dict, Generator, List, Optional,
 
 import lark
 
-from .util import AnyPath, rebuild_lark_tree_with_line_map
+from .util import AnyPath, maybe_add_brackets, rebuild_lark_tree_with_line_map
 
 T = TypeVar("T")
 
@@ -1307,7 +1307,10 @@ class ObjectInitializerArray:
         )
 
     def __str__(self) -> str:
-        initializers = ", ".join([f"({init})" for init in self.initializers])
+        initializers = ", ".join(
+            maybe_add_brackets(str(init), "()")
+            for init in self.initializers
+        )
         return f"{self.name}[{initializers}]"
 
 

--- a/blark/util.py
+++ b/blark/util.py
@@ -620,3 +620,34 @@ def recursively_remove_keys(obj, keys: Set[str]) -> Any:
     if isinstance(obj, (list, tuple)):
         return [recursively_remove_keys(value, keys) for value in obj]
     return obj
+
+
+def maybe_add_brackets(text: str, brackets: str = "[]") -> str:
+    """
+    Add brackets to ``text`` if there are no enclosing brackets.
+
+    Parameters
+    ----------
+    text : str
+        The text to process.
+    brackets : str, optional
+        Add this flavor of brackets - a 2 character string of open and close
+        brackets. Defaults to ``"[]"``.
+    """
+    open_ch, close_ch = brackets
+    if not text or text[0] != open_ch or text[-1] != close_ch:
+        return text
+
+    open_stack: List[int] = []
+    start_to_end: Dict[int, int] = {}
+    for idx, ch in enumerate(text):
+        if ch == open_ch:
+            open_stack.append(idx)
+        elif ch == close_ch:
+            if not open_stack:
+                raise ValueError(f"Unbalanced {brackets} in {text!r}")
+            start_to_end[open_stack.pop(-1)] = idx
+
+    if start_to_end[0] == len(text):
+        return text[1:-1]
+    return text


### PR DESCRIPTION
(This is part of a larger [branch](https://github.com/klauer/blark/compare/master...enh_docs) which got to be unmanageably large - breaking it up into separate PRs)

Fixes:
* Fixes incorrect escape character for double quotes in double-byte strings (`"$""`)
* Don't add more parentheses than required when formatting dataclasses back to code (specifically for `ObjectInitializerArray`)

Clean-up:
* Removed unused grammar rules `structured_var_declaration`, `function_var_decl`, `step_*`, etc.
* Removed grammatical alias `structure_type_name` from `var_spec` (since `simple_spec` covers it just fine)

Test suite:
* More coverage for grammar rules in `test_transformer`
* Coverage check to ensure that all known rules are hit (terminals are a bit buggy there, but I'm not too worried about it)
    * This is opt-in, setting `BLARK_CHECK_GRAMMAR_COVERAGE=1` in the environment prior to running the test suite (since you might only run part of the test suite and it'd be annoying for the coverage check to fail then)
