### PR TITLE
FIX: function call chaining in expressions

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   build:
-    name: "Python 3.10: documentation building"
+    name: Build
     runs-on: ubuntu-20.04
     continue-on-error: false
 
@@ -99,7 +99,7 @@ jobs:
         path: "~/logs"
 
   deploy:
-    name: "Documentation deployment"
+    name: Deploy
     runs-on: ubuntu-20.04
     needs: build
     if: ${{ github.repository_owner == 'klauer' && (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags')) }}

--- a/blark/iec.lark
+++ b/blark/iec.lark
@@ -705,11 +705,13 @@ UNARY_OPERATOR: LOGICAL_NOT
               | PLUS
 
 function_call: symbolic_variable "(" [ param_assignment ( "," param_assignment )* ","? ] ")" DEREFERENCED?
+chained_function_call: function_call ( "." function_call )+
 
 parenthesized_expression: "(" expression ")"
 
 ?primary_expression: parenthesized_expression
                    | function_call
+                   | chained_function_call
                    | _variable
                    | constant
 
@@ -756,7 +758,7 @@ return_statement.1: "RETURN"i ";"+
 
 function_call_statement: function_call ";"+
 
-chained_function_call_statement: function_call ("." function_call)+ ";"+
+chained_function_call_statement: chained_function_call ";"+
 
 param_assignment: [ LOGICAL_NOT ] variable_name "=>" [ expression ] -> output_parameter_assignment
                 | variable_name ":=" [ expression ]

--- a/blark/tests/test_transformer.py
+++ b/blark/tests/test_transformer.py
@@ -358,6 +358,8 @@ def test_bool_literal_roundtrip(name, value, expected):
         param("expression", "NOT (3 - 4)"),
         param("expression", "(i_xTrigger OR NOT i_xPress_OK) AND NOT xVeto"),
         param("expression", "(nEventIdx := (nEventIdx + 1)) = nMaxEvents"),
+        param("expression", "_directoryFileList.Item(_i).ToString()"),
+        param("expression", "_directoryFileList.Item(_i)^.ToString()"),
         param("simple_type_declaration", "TypeName : INT"),
         param("simple_type_declaration", "TypeName : INT := 5"),
         param("simple_type_declaration", "TypeName : INT := 5 + 1 * (2)"),

--- a/blark/transform.py
+++ b/blark/transform.py
@@ -2386,6 +2386,34 @@ class FunctionCall(Expression):
 
 
 @dataclass
+@_rule_handler("chained_function_call")
+class ChainedFunctionCall(Expression):
+    """
+    A set of chained function (function block, method, action, etc.) calls.
+
+    The return value may be dereferenced with a carat (``^``).
+
+    Examples::
+
+        A()^.B()
+        A(1, 2).B().C()
+        A(1, 2, sName:='test', iOutput=>).C().D()
+        A.B[1].C(1, 2)
+    """
+    invocations: List[FunctionCall]
+    meta: Optional[Meta] = meta_field()
+
+    @staticmethod
+    def from_lark(*invocations: FunctionCall) -> ChainedFunctionCall:
+        return ChainedFunctionCall(
+            invocations=list(invocations)
+        )
+
+    def __str__(self) -> str:
+        return ".".join(str(invocation) for invocation in self.invocations)
+
+
+@dataclass
 @_rule_handler("var1")
 class DeclaredVariable:
     """
@@ -3828,9 +3856,9 @@ class ChainedFunctionCallStatement(Statement):
     meta: Optional[Meta] = meta_field()
 
     @staticmethod
-    def from_lark(*invocations: FunctionCall) -> ChainedFunctionCallStatement:
+    def from_lark(chain: ChainedFunctionCall) -> ChainedFunctionCallStatement:
         return ChainedFunctionCallStatement(
-            invocations=list(invocations)
+            invocations=chain.invocations,
         )
 
     def __str__(self) -> str:


### PR DESCRIPTION
Closes #93 

* Expressions may include chained function calls
* Prior to this PR, only statements defined in such a way were supported
* Adds `chained_function_call` grammar rule and `ChainedFunctionCall` class