### PR TITLE
Increase priority of constant rule in grammar (#108)

### DIFF
--- a/blark/iec.lark
+++ b/blark/iec.lark
@@ -430,7 +430,6 @@ edge_declaration: var1_list ":" _BOOL ( R_EDGE | F_EDGE )
 
 ?var_init_decl: array_var_init_decl
               | structured_var_init_decl
-              | string_var_declaration
               | var1_init_decl
               | fb_decl
 
@@ -499,19 +498,12 @@ location: _AT direct_variable
 
 global_var_list: global_var_name ( "," global_var_name )*
 
-?string_var_declaration: single_byte_string_var_declaration
-                       | double_byte_string_var_declaration
-
-single_byte_string_var_declaration: var1_list ":" single_byte_string_spec
-
 bracketed_expression: "[" expression "]"
 
 string_spec_length: parenthesized_expression
                   | bracketed_expression
 
 single_byte_string_spec: STRING [ string_spec_length ] [ ":=" SINGLE_BYTE_CHARACTER_STRING ]
-
-double_byte_string_var_declaration: var1_list ":" double_byte_string_spec
 
 double_byte_string_spec: WSTRING [ string_spec_length ] [ ":=" DOUBLE_BYTE_CHARACTER_STRING ]
 

--- a/blark/iec.lark
+++ b/blark/iec.lark
@@ -36,11 +36,11 @@ _library_element_declaration: data_type_declaration
 IDENTIFIER: /[A-Za-z_][A-Za-z0-9_]*/i
 
 // B.1.2
-constant: time_literal
-        | numeric_literal
-        | string_literal
-        | bit_string_literal
-        | boolean_literal
+constant.1: time_literal
+          | numeric_literal
+          | string_literal
+          | bit_string_literal
+          | boolean_literal
 
 // B.1.2.1
 BIT_STRING: /(1|0)(_?(1|0))*/

--- a/blark/transform.py
+++ b/blark/transform.py
@@ -2494,7 +2494,7 @@ InitDeclarationType = Union[
     EnumeratedTypeInitialization,
     ArrayTypeInitialization,
     InitializedStructure,
-    _GenericInit,  # StringVariableInitDeclaration, EdgeDeclaration
+    _GenericInit,  # EdgeDeclaration
 ]
 
 
@@ -2566,44 +2566,6 @@ class StructuredVariableInitDeclaration(InitDeclaration):
     variables: List[DeclaredVariable]
     init: InitializedStructure
     meta: Optional[Meta] = meta_field()
-
-
-@dataclass
-@_rule_handler(
-    "single_byte_string_var_declaration",
-    "double_byte_string_var_declaration",
-    comments=True
-)
-class StringVariableInitDeclaration(InitDeclaration):
-    """
-    A declaration of one or more variables using single/double byte strings,
-    with an optinoal initialization value.
-
-    Examples::
-
-        sVar1 : STRING(2_500_000) := 'test1'
-        sVar2, sVar3 : STRING(Param.iLower) := 'test2'
-        sVar4, sVar5 : WSTRING(Param.iLower) := "test3"
-    """
-    variables: List[DeclaredVariable]
-    spec: StringTypeSpecification
-    value: Optional[lark.Token]
-    init: _GenericInit
-    meta: Optional[Meta] = meta_field()
-
-    @staticmethod
-    def from_lark(variables: List[DeclaredVariable], string_info: StringTypeInitialization):
-        return StringVariableInitDeclaration(
-            variables=variables,
-            spec=string_info.spec,
-            value=string_info.value,
-            init=_GenericInit(
-                base_type_name=str(string_info.spec.base_type_name),
-                full_type_name=str(string_info.spec.full_type_name),
-                value=str(string_info.value),
-                repr=join_if(string_info.spec, " := ", string_info.value),
-            )
-        )
 
 
 @dataclass
@@ -3294,7 +3256,6 @@ class Property:
 
 VariableInitDeclaration = Union[
     ArrayVariableInitDeclaration,
-    StringVariableInitDeclaration,
     VariableOneInitDeclaration,
     FunctionBlockDeclaration,
     EdgeDeclaration,


### PR DESCRIPTION
Fixes #108. I also added a test that verifies some basic expectations about the parsing of boolean literals. It does so by checking that some key token (e.g. _constant_, _TRUE_VALUE_) can be found somewhere in the parse tree. The test is parametrized so that it can be reused for further checks of a similar kind.