### PR TITLE
Improved HTML formatter

### DIFF
--- a/blark/html.py
+++ b/blark/html.py
@@ -1,128 +1,156 @@
 """Syntax-highlighted HTML file writer."""
 from __future__ import annotations
 
-import collections
 import dataclasses
 import pathlib
-from typing import Any, DefaultDict, Dict, Generator, List, Optional
+from typing import Any, Optional, Union
 
 import lark
+from lxml import etree
 
 from .output import OutputBlock, register_output_handler
 
 
 @dataclasses.dataclass(frozen=True)
-class HighlighterAnnotation:
-    """A single HTML tag annotation which applies to a position range of source code."""
+class CodeSpan:
+    #: Start position (inclusive)
+    start: int
+    #: End position (exclusive)
+    end: int
 
-    name: str
-    terminal: bool
-    is_open_tag: bool
-    other_tag_pos: int
+    @staticmethod
+    def of(item: Union[lark.Tree, lark.Token]) -> Optional[CodeSpan]:
+        """Get the code span of the given Tree or Token"""
+        ref = item.meta if isinstance(item, lark.Tree) else item
+        if (start := getattr(ref, 'start_pos', None)) is not None:
+            if (end := getattr(ref, 'end_pos', None)) is not None:
+                return CodeSpan(start, end)
+        return None
 
-    def __str__(self) -> str:
-        return self.as_string()
-
-    def as_string(self, tag: str = "span") -> str:
-        # some options here?
-        if not self.is_open_tag:
-            return f'</{tag}>'
-
-        if self.terminal:
-            classes = " ".join(("term", self.name))
-        else:
-            classes = " ".join(("rule", self.name))
-
-        return f'<{tag} class="{classes}">'
+    def contains(self, other: CodeSpan) -> bool:
+        """Determine if the code span contains another code span"""
+        return other.start >= self.start and other.end <= self.end
 
 
-def _add_annotation_pair(
-    annotations: DefaultDict[int, List[HighlighterAnnotation]],
-    name: str,
-    start_pos: int,
-    end_pos: int,
-    terminal: bool,
-) -> None:
+class RemoveNone(lark.Transformer):
+    """Remove all None elements from a lark tree"""
+    def __default__(
+        self,
+        data: lark.Token,
+        children: list,
+        meta: lark.tree.Meta
+    ) -> lark.Tree:
+        return lark.Tree(data, [c for c in children if c is not None], meta)
+
+
+@dataclasses.dataclass(frozen=True)
+class TokenPlacement:
+    #: Token's parent tree
+    tree: lark.Tree
+    #: Index of the token in tree.children
+    child_index: int
+
+
+def find_placement(
+    token: lark.Token,
+    tree: lark.Tree
+) -> Optional[TokenPlacement]:
+    """Find a placement for the token within the given tree according to token's code span."""
+    tree_span = CodeSpan.of(tree)
+    token_span = CodeSpan.of(token)
+
+    if not (tree_span and token_span and tree_span.contains(token_span)):
+        return None
+
+    for child in tree.children:
+        if isinstance(child, lark.Tree):
+            if placement := find_placement(token, child):
+                return placement
+
+    for index, child in enumerate(tree.children):
+        child_span = CodeSpan.of(child)
+        if child_span and child_span.start > token_span.start:
+            return TokenPlacement(tree, index)
+
+    return TokenPlacement(tree, len(tree.children))
+
+
+def insert_comments(
+    tree: lark.Tree,
+    comments: list[lark.Token],
+    source_code: str
+) -> lark.Tree:
+    """Combine code and comments into a single lark tree"""
+    if not comments:
+        return tree
+
+    all_spans = [CodeSpan.of(tree)] + [CodeSpan.of(token) for token in comments]
+    valid_spans = [span for span in all_spans if span]
+
+    meta = lark.tree.Meta()
+    meta.start_pos = min(span.start for span in valid_spans)
+    meta.end_pos = max(span.end for span in valid_spans)
+
+    # Use no-op transformer to create a copy of the tree.
+    new_tree: lark.Tree = lark.Transformer().transform(tree)
+    # Assign metadata to the copied tree.
+    new_tree = lark.Tree(new_tree.data, new_tree.children, meta)
+
+    for comment in comments:
+        if placement := find_placement(comment, new_tree):
+            placement.tree.children.insert(placement.child_index, comment)
+
+    return new_tree
+
+
+def html_element(*, cls: str, text: str = None) -> etree.Element:
+    """Create a HTML element with the given class"""
+    element = etree.Element("span")
+    element.set("class", cls)
+    if text is not None:
+        element.text = text
+    return element
+
+
+def lark_item_to_element(
+    item: Union[lark.Tree, lark.Token],
+    source_code: str,
+    output_pos: int
+) -> tuple[etree.Element, int]:
     """
-    Add a pair of HTML tag annotations to the position-indexed list.
-
-    Parameters
-    ----------
-    annotations : DefaultDict[int, List[HighlighterAnnotation]]
-        Annotations keyed by 0-indexed string position.
-    name : str
-        Name of the annotation.
-    start_pos : int
-        String index position which the annotation applies to.
-    end_pos : int
-        String index position which the annotation ends at.
-    terminal : bool
-        Whether this is a TERMINAL (True) or a rule (false).
+    Convert a lark item to an lxml element. Return the element and the position in the source code
+    after this item.
     """
-    annotations[start_pos].append(
-        HighlighterAnnotation(
-            name=name,
-            terminal=terminal,
-            is_open_tag=True,
-            other_tag_pos=end_pos,
-        )
-    )
-    annotations[end_pos].append(
-        HighlighterAnnotation(
-            name=name,
-            terminal=terminal,
-            is_open_tag=False,
-            other_tag_pos=start_pos,
-        )
-    )
+    code_span = CodeSpan.of(item) or CodeSpan(output_pos, output_pos)
 
+    if isinstance(item, lark.Tree):
+        element = html_element(cls=item.data)
+        running_pos = code_span.start
 
-def get_annotations(tree: lark.Tree) -> DefaultDict[int, List[HighlighterAnnotation]]:
-    """Get annotations for syntax elements in the given parse tree."""
-    annotations: DefaultDict[int, List[HighlighterAnnotation]] = collections.defaultdict(
-        list
-    )
+        def append_text_up_to(pos: int):
+            nonlocal running_pos
+            if text := source_code[running_pos:pos]:
+                if len(element) == 0:
+                    element.text = text
+                else:
+                    element[-1].tail = text
+            running_pos = pos
 
-    for subtree in tree.iter_subtrees():
-        if hasattr(subtree.meta, "start_pos"):
-            _add_annotation_pair(
-                annotations,
-                name=subtree.data,
-                terminal=False,
-                start_pos=subtree.meta.start_pos,
-                end_pos=subtree.meta.end_pos,
-            )
-        for child in subtree.children:
-            if isinstance(child, lark.Token):
-                if child.start_pos is not None and child.end_pos is not None:
-                    _add_annotation_pair(
-                        annotations,
-                        name=child.type,
-                        terminal=True,
-                        start_pos=child.start_pos,
-                        end_pos=child.end_pos,
-                    )
-    return annotations
+        for child in item.children:
+            if child_span := CodeSpan.of(child):
+                append_text_up_to(child_span.start)
 
+            child_element, running_pos = lark_item_to_element(child, source_code, running_pos)
+            element.append(child_element)
 
-def apply_annotations_to_code(
-    code: str,
-    annotations: Dict[int, List[HighlighterAnnotation]]
-) -> str:
-    def annotate() -> Generator[str, None, None]:
-        pos = 0
-        for pos, ch in enumerate(code):
-            for ann in reversed(annotations.get(pos, [])):
-                yield str(ann)
-            if ch == " ":
-                yield "&nbsp;"
-            else:
-                yield ch
+        append_text_up_to(code_span.end)
+    else:
+        assert isinstance(item, lark.Token)
+        element = html_element(
+            cls=item.type,
+            text=source_code[code_span.start:code_span.end])
 
-        for ann in annotations.get(pos + 1, []):
-            yield str(ann)
-
-    return "".join(annotate())
+    return element, code_span.end
 
 
 @dataclasses.dataclass
@@ -131,35 +159,44 @@ class HtmlWriter:
     source_filename: Optional[pathlib.Path]
     block: OutputBlock
 
-    @property
-    def source_code(self) -> str:
-        """The source code associated with the block."""
-        assert self.block.origin is not None
-        return self.block.origin.source_code
-
     def to_html(self) -> str:
-        """HTML tag-annotated source code."""
-        assert self.block.origin is not None
-        assert self.block.origin.tree is not None
-        annotations = get_annotations(self.block.origin.tree)
+        """Format source code as HTML"""
+        origin = self.block.origin
+        assert origin is not None
+        assert origin.tree is not None
 
-        for comment in self.block.origin.comments:
-            if comment.start_pos is not None and comment.end_pos is not None:
-                _add_annotation_pair(
-                    annotations,
-                    name=comment.type,
-                    start_pos=comment.start_pos,
-                    end_pos=comment.end_pos,
-                    terminal=True,
-                )
+        cleaned_tree = RemoveNone().transform(origin.tree)
+        tree_with_comments = insert_comments(cleaned_tree, origin.comments, origin.source_code)
 
-        return apply_annotations_to_code(self.source_code, annotations)
+        root = html_element(cls="blark")
+
+        origin_section = html_element(
+            cls="blark_origin",
+            text=origin.identifier or '')
+        root.append(origin_section)
+
+        code_section = html_element(cls="blark_code")
+
+        # Handle any leading text before the tree
+        tree_span = CodeSpan.of(tree_with_comments) or CodeSpan(0, 0)
+        if leading := origin.source_code[0:tree_span.start]:
+            code_section.text = leading
+
+        # Convert code tree to lxml tree.
+        element, _ = lark_item_to_element(
+            tree_with_comments, origin.source_code, tree_span.start
+        )
+        code_section.append(element)
+        root.append(code_section)
+
+        # Serialize to HTML.
+        return etree.tostring(root, encoding='unicode', method='html')
 
     @staticmethod
     def save(
         user: Any,
         source_filename: Optional[pathlib.Path],
-        parts: List[OutputBlock],
+        parts: list[OutputBlock],
     ) -> str:
         """Convert the source code block to HTML and return it."""
         result = []


### PR DESCRIPTION
This PR fixes several problems with the HTML formatter. The main issue with the current formatter is that the order of some element classes is reversed. To illustrate: save the following code to `example.txt` and run `blark format -of html example.txt`.
```
TYPE ST_MyStruct :
    STRUCT
        foo : BOOL;
    END_STRUCT
END_TYPE
```
In the output, you get (line breaks added for clarity)
```
<span class="term IDENTIFIER">
<span class="rule structure_type_declaration">
ST_MyStruct
```
This is incorrect: `IDENTIFIER` should have been nested within `structure_type_declaration`, not the other way around. The same happens with variable definitions:
```
<span class="rule var1_list">
<span class="rule var1">
<span class="term IDENTIFIER">
<span class="rule variable_name">
foo
```
Order of `var1_list` and `var1` is correct, but `IDENTIFIER` again comes before `variable_name`.

In addition to that, the current HTML formatter has a few other undesirable properties:

* It converts all spaces to `&nbsp;`. This significantly increases the output length, and it's not even necessary: the HTML output needs to be styled with CSS anyway, and in CSS, literal space preservation can be simply achieved with `white-space: pre`.
* All HTML classes include either `rule` or `term` at the beginning. In my opinion, this just inflates the output with no real benefit.
* Reserved characters like `<`, `>`, and `&` are passed through instead of being converted to entity names (`&lt;` etc.). This is not in accordance with the HTML spec.
* Code origins (`block.origin.identifier` in python terms) are not included in the output. This becomes a problem when styling a HTML produced from an entire TcPOU, as there are no HTML entities that could be used as separators between different sections in the TcPOU, so it's hard to distinguish what belongs where.

There may be more; I don't really recall because I initially started working on this a while ago.

The code in this PR fixes all of that. Since lxml is already one of blark's main dependencies and thus comes "for free", I chose to use it internally. The resulting HTML is thus guaranteed to be syntactically correct. I have added three new HTML classes to make styling easier:

* class `blark`: This wraps the entire HTML output.
* class `blark_origin`: Contains the code origin. Can be styled with `display: none` if one doesn't want to see it.
* class `blark_code`: Contains the code itself.

Please review and let me know if you identify any potential issues.